### PR TITLE
Set up Dash app, basic filtering components, data loader

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,6 +13,10 @@ exclude =
 
 max-line-length = 79
 
+# Otherwise, limits readability of comparing against booleans in pandas
+# (e.g., https://github.com/astral-sh/ruff/issues/1852)
+ignore = E712
+
 ; ignore =
 ; per-file-ignores =
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "data"]
+	path = data
+	url = https://github.com/neurodatascience/us_climate_emotions_data

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ tox
 ```
 
 Pre-commit will then run all those hooks on the files you have staged for commit.
-Note that if some of those hooks fail you may have to edit some files and stage them again.
+Note that while several hooks will auto-fix files when they have failed the checks
+(meaning you just need to stage the edited files),
+for others, if the hooks fail you may have to edit some files manually before staging them again.
 
 ### To know more about pre-commit
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,37 @@ Interactive web app for visualizing US survey results about climate change emoti
 
 
 ## Development environment
-Create a Python environment and install the app and developer dependencies:
-
-```bash
-pip install requirements.txt
-pip install requirements_dev.txt
-```
-
-To set up code formatting and linting, run:
-```bash
-tox
-```
 
 See also the [Contributing Guidelines](CONTRIBUTING.md) for more information.
+
+1. Clone the repository
+    ```bash
+    git clone https://github.com/neurodatascience/us_climate_emotions_map.git
+
+    # Or, to clone and directly install the data submodule all at once:
+    git clone --recurse-submodules --branch main https://github.com/neurodatascience/us_climate_emotions_map.git
+    ```
+
+2. Create a Python environment and install the app and developer dependencies:
+
+    ```bash
+    pip install -r requirements.txt
+    pip install -r requirements_dev.txt
+    ```
+
+2. To set up code formatting and linting, run:
+    ```bash
+    tox
+    ```
+    Now, a number of code linters and formatters should automatically run when you try to commit a local change.
+
+3. To install the [data](https://github.com/neurodatascience/us_climate_emotions_data) submodule, if you did not do so in step 1:
+    ```bash
+    git submodule init
+    git submodule update
+    ```
+
+    To update the submodule in your local clone to the latest revision in this repository:
+    ```bash
+    git submodule update
+    ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Interactive web app for visualizing US survey results about climate change emoti
 
 See also the [Contributing Guidelines](CONTRIBUTING.md) for more information.
 
+To install the app from source:
+
 1. Clone the repository
     ```bash
     git clone https://github.com/neurodatascience/us_climate_emotions_map.git
@@ -37,3 +39,8 @@ See also the [Contributing Guidelines](CONTRIBUTING.md) for more information.
     ```bash
     git submodule update
     ```
+
+To launch the app locally:
+```bash
+python -m climate_emotions_map.app
+```

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -1,0 +1,23 @@
+"""Main file to run the Dash app."""
+
+import os
+
+import dash_mantine_components as dmc
+from dash import Dash
+
+from .layout import construct_layout
+
+# Currently needed by DMC, https://www.dash-mantine-components.com/getting-started#simple-usage
+os.environ["REACT_VERSION"] = "18.2.0"
+
+app = Dash(
+    __name__,
+    title="US Climate Emotions Map",
+)
+
+app.layout = dmc.MantineProvider(construct_layout(), forceColorScheme="light")
+
+server = app.server
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/climate_emotions_map/data_loader.py
+++ b/climate_emotions_map/data_loader.py
@@ -1,20 +1,33 @@
+"""
+Load survey data and data dictionaries into dataframes.
+
+Example usage: After importing SURVEY_DATA in another script, the dataframe for the
+opinions_party.tsv data file can be accessed with SURVEY_DATA["opinions_party.tsv"].
+"""
+
 from pathlib import Path
 
 import pandas as pd
 
 
 def load_data_file(file: str) -> pd.DataFrame:
-    """
-    Load the data from one TSV file into a dataframe.
-    """
+    """Load a TSV data file into a dataframe."""
     return pd.read_csv(
         Path(__file__).parents[1] / "data" / "survey_results" / file, sep="\t"
     )
 
 
-def load_survey_data():
+def load_data_dictionary(file: str) -> pd.DataFrame:
+    """Load a data dictionary TSV into a dataframe."""
+    return pd.read_csv(
+        Path(__file__).parents[1] / "data" / "data_dictionaries" / file,
+        sep="\t",
+    )
+
+
+def load_survey_data() -> dict[str, pd.DataFrame]:
     """
-    Load all survey result TSV files into dataframes.
+    Load all survey result TSV files of interest.
     Climate impact data is excluded because it is not used in the dashboard.
     """
     data_files = [
@@ -34,4 +47,22 @@ def load_survey_data():
     return data_frames
 
 
+def load_data_dictionaries() -> dict[str, pd.DataFrame]:
+    """Load the data dictionaries for the survey data."""
+    data_files = [
+        "impacts_list.tsv",
+        "outcome_dictionary.tsv",
+        "question_dictionary.tsv",
+        "state_abbreviations.tsv",
+        "subquestion_dictionary.tsv",
+    ]
+
+    data_frames = {}
+    for file in data_files:
+        data_frames[file] = load_data_dictionary(file)
+
+    return data_frames
+
+
 SURVEY_DATA = load_survey_data()
+DATA_DICTIONARIES = load_data_dictionaries()

--- a/climate_emotions_map/data_loader.py
+++ b/climate_emotions_map/data_loader.py
@@ -25,6 +25,11 @@ def load_data_dictionary(file: str) -> pd.DataFrame:
     )
 
 
+def remove_ignored_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove rows from a dataframe that have a value of TRUE in the "ignore" column."""
+    return df[df["ignore"] == False]
+
+
 def load_survey_data() -> dict[str, pd.DataFrame]:
     """
     Load all survey result TSV files of interest.
@@ -60,6 +65,8 @@ def load_data_dictionaries() -> dict[str, pd.DataFrame]:
     data_frames = {}
     for file in data_files:
         data_frames[file] = load_data_dictionary(file)
+        if "ignore" in data_frames[file].columns:
+            data_frames[file] = remove_ignored_rows(data_frames[file])
 
     return data_frames
 

--- a/climate_emotions_map/data_loader.py
+++ b/climate_emotions_map/data_loader.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pandas as pd
+
+
+def load_data_file(file: str) -> pd.DataFrame:
+    """
+    Load the data from one TSV file into a dataframe.
+    """
+    return pd.read_csv(
+        Path(__file__).parents[1] / "data" / "survey_results" / file, sep="\t"
+    )
+
+
+def load_survey_data():
+    """
+    Load all survey result TSV files into dataframes.
+    Climate impact data is excluded because it is not used in the dashboard.
+    """
+    data_files = [
+        "opinions_party.tsv",
+        "opinions_state.tsv",
+        "opinions_wholesample.tsv",
+        "sampledesc_state.tsv",
+        "sampledesc_wholesample.tsv",
+        "samplesizes_party.tsv",
+        "samplesizes_state.tsv",
+    ]
+
+    data_frames = {}
+    for file in data_files:
+        data_frames[file] = load_data_file(file)
+
+    return data_frames
+
+
+SURVEY_DATA = load_survey_data()

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -4,6 +4,8 @@ import dash_mantine_components as dmc
 
 from . import utility as utils
 
+# TODO: Add component IDs!
+
 
 def create_state_dropdown():
     """Create the dropdown for states and state clusters."""
@@ -22,6 +24,44 @@ def create_party_switch():
     return dmc.Switch(
         label="Stratify by party affiliation",
         checked=False,
+    )
+
+
+def create_response_threshold_control():
+    """Create the segmented control for selecting the endorsement threshold to display."""
+    label = dmc.Text(
+        "Display results for responses rated:", size="sm"
+    )  # "response endorsements of"?
+
+    segmented_control = dmc.SegmentedControl(
+        data=[
+            {"label": "Any endorsement level", "value": "all"},
+            {"label": "3+ (moderately and above)", "value": "3+"},
+            {"label": "4+ (very much and above)", "value": "4+"},
+        ],
+        orientation="vertical",
+        fullWidth=True,
+    )
+
+    return dmc.Stack(
+        gap=5,
+        children=[label, segmented_control],
+    )
+
+
+def create_navbar():
+    """Create the navbar for the dashboard."""
+    return dmc.AppShellNavbar(
+        children=dmc.Stack(
+            mt=25,
+            px=25,
+            gap="lg",
+            children=[
+                create_state_dropdown(),
+                create_party_switch(),
+                create_response_threshold_control(),
+            ],
+        )
     )
 
 
@@ -50,10 +90,8 @@ def create_header():
                         dmc.GridCol(
                             dmc.Group(
                                 justify="flex-end",
-                                children=[
-                                    create_state_dropdown(),
-                                    create_party_switch(),
-                                ],
+                                # TODO: Add GitHub link? Not sure if needed/wanted.
+                                # TODO: Add link to paper
                             ),
                             span="auto",
                         ),
@@ -67,5 +105,5 @@ def create_header():
 def construct_layout():
     """Generate the overall dashboard layout."""
     return dmc.AppShell(
-        children=[create_header()],
+        children=[create_header(), create_navbar()], header={"height": 70}
     )

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -125,10 +125,33 @@ def create_header():
     )
 
 
+def create_question_title():
+    """Create the title for the main content of the dashboard."""
+    # TODO: This will be updated in a callback to reflect the selected question and subquestion.
+    return dmc.Title(
+        "This is the question: This is the subquestion", order=3, fw=300
+    )
+
+
+def create_main():
+    """Create the main content of the dashboard."""
+    return dmc.AppShellMain(
+        children=[
+            dmc.Container(
+                my=25,
+                mx="xs",
+                children=[
+                    create_question_title(),
+                ],
+            )
+        ]
+    )
+
+
 def construct_layout():
     """Generate the overall dashboard layout."""
     return dmc.AppShell(
-        children=[create_header(), create_navbar()],
+        children=[create_header(), create_navbar(), create_main()],
         header={"height": 70},
         navbar={"width": 400},
     )

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -4,12 +4,11 @@ import dash_mantine_components as dmc
 
 from . import utility as utils
 
-# TODO: Add component IDs!
-
 
 def create_state_dropdown():
     """Create the dropdown for states and state clusters."""
     return dmc.Select(
+        id="state-select",
         label="Select a state",
         placeholder="Showing national results",
         data=utils.get_state_options(),
@@ -22,6 +21,7 @@ def create_state_dropdown():
 def create_party_switch():
     """Create the switch for stratifying data by party affiliation."""
     return dmc.Switch(
+        id="party-stratify-switch",
         label="Stratify by party affiliation",
         checked=False,
     )
@@ -34,6 +34,7 @@ def create_response_threshold_control():
     )  # "response endorsements of"?
 
     segmented_control = dmc.SegmentedControl(
+        id="response-threshold-control",
         data=[
             {"label": "Any endorsement level", "value": "all"},
             {"label": "3+ (moderately and above)", "value": "3+"},

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -17,6 +17,14 @@ def create_state_dropdown():
     )
 
 
+def create_party_switch():
+    """Create the switch for stratifying data by party affiliation."""
+    return dmc.Switch(
+        label="Stratify by party affiliation",
+        checked=False,
+    )
+
+
 def create_header():
     """Create the header for the dashboard."""
     return dmc.AppShellHeader(
@@ -44,6 +52,7 @@ def create_header():
                                 justify="flex-end",
                                 children=[
                                     create_state_dropdown(),
+                                    create_party_switch(),
                                 ],
                             ),
                             span="auto",

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -1,0 +1,62 @@
+"""Generate the layout for the dashboard."""
+
+import dash_mantine_components as dmc
+
+from . import utility as utils
+
+
+def create_state_dropdown():
+    """Create the dropdown for states and state clusters."""
+    return dmc.Select(
+        label="Select a state",
+        placeholder="Showing national results",
+        data=utils.get_state_options(),
+        clearable=True,
+        searchable=True,
+        nothingFoundMessage="No matches",
+    )
+
+
+def create_header():
+    """Create the header for the dashboard."""
+    return dmc.AppShellHeader(
+        # See https://www.dash-mantine-components.com/style-props
+        px=25,
+        children=[
+            dmc.Stack(
+                justify="center",
+                h=70,
+                children=dmc.Grid(
+                    justify="space-between",
+                    align="center",
+                    children=[
+                        dmc.GridCol(
+                            children=dmc.Anchor(
+                                "US Climate Emotions Map 2024",
+                                size="xl",
+                                href="/",
+                                underline=False,
+                            ),
+                            span="content",
+                        ),
+                        dmc.GridCol(
+                            dmc.Group(
+                                justify="flex-end",
+                                children=[
+                                    create_state_dropdown(),
+                                ],
+                            ),
+                            span="auto",
+                        ),
+                    ],
+                ),
+            )
+        ],
+    )
+
+
+def construct_layout():
+    """Generate the overall dashboard layout."""
+    return dmc.AppShell(
+        children=[create_header()],
+    )

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -4,6 +4,27 @@ import dash_mantine_components as dmc
 
 from . import utility as utils
 
+DEFAULT_QUESTION = {"question": "q2", "sub_question": 1}
+
+
+def create_question_dropdown():
+    """Create the dropdown for subquestions grouped by question."""
+    return dmc.Select(
+        id="question-select",
+        label="Select a question",  # "Select a sub-question"?
+        data=utils.get_question_options(),
+        value=f"{DEFAULT_QUESTION['question']}_{DEFAULT_QUESTION['sub_question']}",
+        allowDeselect=False,
+        clearable=False,
+        searchable=True,
+        nothingFoundMessage="No matches",
+        styles={
+            "group": {"marginTop": 10},
+            "option": {"paddingTop": 2, "paddingBottom": 2},
+            "input": {"textOverflow": "ellipsis"},
+        },
+    )
+
 
 def create_state_dropdown():
     """Create the dropdown for states and state clusters."""
@@ -58,6 +79,7 @@ def create_navbar():
             px=25,
             gap="lg",
             children=[
+                create_question_dropdown(),
                 create_state_dropdown(),
                 create_party_switch(),
                 create_response_threshold_control(),
@@ -106,5 +128,7 @@ def create_header():
 def construct_layout():
     """Generate the overall dashboard layout."""
     return dmc.AppShell(
-        children=[create_header(), create_navbar()], header={"height": 70}
+        children=[create_header(), create_navbar()],
+        header={"height": 70},
+        navbar={"width": 400},
     )

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -1,6 +1,6 @@
 """Utility functions for the Climate Emotions Map app."""
 
-from .data_loader import SURVEY_DATA
+from .data_loader import DATA_DICTIONARIES, SURVEY_DATA
 
 
 def get_state_options():
@@ -10,3 +10,38 @@ def get_state_options():
         {"label": state, "value": state}
         for state in SURVEY_DATA["samplesizes_state.tsv"]["state"]
     ]
+
+
+def get_question_options():
+    """Construct the data for the question dropdown, where each option is a subquestion and subquestions are grouped by question."""
+    subquestions_grouped = DATA_DICTIONARIES[
+        "subquestion_dictionary.tsv"
+    ].groupby("question")
+
+    data = []
+    for _, q_row in DATA_DICTIONARIES["question_dictionary.tsv"].iterrows():
+        question = q_row["question"]
+        question_label = q_row["full_text"]
+
+        group = subquestions_grouped.get_group(question)
+        if group.shape[0] > 1:
+            data_group = {"group": question_label, "items": []}
+            for _, sq_row in group.iterrows():
+                # NOTE: Option `value` must be a string for DMC.
+                data_group["items"].append(
+                    {
+                        "label": sq_row["full_text"],
+                        "value": f"{question}_{sq_row['sub_question']}",
+                    }
+                )
+        else:
+            # If there is only one subquestion (meaning no subquestions),
+            # create a group with an empty group label so it still receives the correct whitespace around it in the dropdown
+            data_group = {
+                "group": "",
+                "items": [{"label": question_label, "value": f"{question}_1"}],
+            }
+
+        data.append(data_group)
+
+    return data

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -1,0 +1,12 @@
+"""Utility functions for the Climate Emotions Map app."""
+
+from .data_loader import SURVEY_DATA
+
+
+def get_state_options():
+    """Get the options for the state dropdown."""
+    # TODO: The state values include cluster labels in parentheses, e.g. (Cluster F). Can remove from label if desired.
+    return [
+        {"label": state, "value": state}
+        for state in SURVEY_DATA["samplesizes_state.tsv"]["state"]
+    ]


### PR DESCRIPTION
Closes #1 

Changes proposed in this pull request:
- Added module to load data files and data dictionaries in as dataframes
  - Non-relevant questions removed from data dictionary dfs upon being loaded
- Set up Dash app with the following components:
  - Question dropdown
  - State dropdown
  - Switch to stratify by party
  - Segmented control to select an endorsement threshold
- Add instructions for running Dash app locally to README