### PR TITLE
[MNT] Remove invalid black config from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.black]
 line-length = 79
-safe = true
 
 [tool.codespell]
 # ignore-words =


### PR DESCRIPTION
Avoids pre-commit complaining when it runs the `black` hook.