### PR TITLE
[ENH] Add responsive map, impact dropdown, (sub)titles to app

### DIFF
--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -8,13 +8,13 @@ from dash.exceptions import PreventUpdate
 
 from . import utility as utils
 from .data_loader import NATIONAL_SAMPLE_SIZE, SURVEY_DATA
-from .layout import (
+from .layout import construct_layout
+from .make_map import make_map
+from .utility import (
     DEFAULT_QUESTION,
     NO_THRESHOLD_OPTION_VALUE,
     OPINION_COLORMAP,
-    construct_layout,
 )
-from .make_map import make_map
 
 # Currently needed by DMC, https://www.dash-mantine-components.com/getting-started#simple-usage
 os.environ["REACT_VERSION"] = "18.2.0"
@@ -90,6 +90,28 @@ def update_drawer_sample_size(value):
     if value is None:
         return f"Sample size: {NATIONAL_SAMPLE_SIZE}"
     return f"Sample size: {df[df['state'] == value]['n'].values[0]}"
+
+
+@callback(
+    Output("map-title", "children"),
+    Input("response-threshold-control", "value"),
+)
+def update_map_title(threshold):
+    """Update the map title based on the selected threshold."""
+    # TODO: Revisit if we want to fix the threshold for the opinion data for the map
+    if threshold == NO_THRESHOLD_OPTION_VALUE:
+        raise PreventUpdate
+    return utils.create_map_title(threshold)
+
+
+@callback(
+    Output("map-subtitle", "children"),
+    Input("question-select", "value"),
+)
+def update_map_subtitle(question_value):
+    """Update the map subtitle based on the selected question."""
+    question, subquestion = utils.extract_question_subquestion(question_value)
+    return utils.create_question_subtitle(question, subquestion)
 
 
 @callback(

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -11,6 +11,7 @@ from .data_loader import NATIONAL_SAMPLE_SIZE, SURVEY_DATA
 from .layout import construct_layout
 from .make_descriptive_plots import make_descriptive_plots
 from .make_map import make_map
+from .make_stacked_bar_plots import make_stacked_bar
 from .utility import (  # IMPACT_COLORMAP,
     DEFAULT_QUESTION,
     NO_THRESHOLD_OPTION_VALUE,
@@ -186,6 +187,39 @@ def reset_response_threshold_control(question_value, threshold):
     ):
         return DEFAULT_QUESTION["outcome"]
     raise PreventUpdate
+
+
+@callback(
+    Output("stacked-bar-plot", "figure"),
+    [
+        Input("question-select", "value"),
+        Input("state-select", "value"),
+        Input("party-stratify-switch", "checked"),
+        Input("response-threshold-control", "value"),
+    ],
+    prevent_initial_call=True,
+)
+def update_stacked_bar_plots(
+    question_value, state, is_party_stratify_checked, threshold
+):
+    """Update the stacked bar plots based on the selected question."""
+    question, subquestion = utils.extract_question_subquestion(question_value)
+
+    # TODO: Make no threshold value None instead of "all"?
+    if threshold == NO_THRESHOLD_OPTION_VALUE:
+        threshold = None
+
+    figure = make_stacked_bar(
+        question=question,
+        subquestion=subquestion,
+        state=state,
+        stratify=is_party_stratify_checked,
+        threshold=threshold,
+        binarize_threshold=True,
+    )
+    return figure
+
+    # raise PreventUpdate
 
 
 if __name__ == "__main__":

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -12,10 +12,9 @@ from .layout import construct_layout
 from .make_descriptive_plots import make_descriptive_plots
 from .make_map import make_map
 from .make_stacked_bar_plots import make_stacked_bar
-from .utility import (  # IMPACT_COLORMAP,
+from .utility import (  # IMPACT_COLORMAP,; OPINION_COLORMAP,
     DEFAULT_QUESTION,
     NO_THRESHOLD_OPTION_VALUE,
-    OPINION_COLORMAP,
 )
 
 # Currently needed by DMC, https://www.dash-mantine-components.com/getting-started#simple-usage
@@ -157,9 +156,8 @@ def update_map(question_value, threshold, state, impact):
         outcome=threshold,
         clicked_state=state,
         impact=impact,
-        opinion_colormap=OPINION_COLORMAP,
-        show_impact_as_gradient=False,
-        impact_marker_size_scale=0.6,
+        # opinion_colormap=OPINION_COLORMAP,
+        show_impact_as_gradient=True,
         # impact_colormap=IMPACT_COLORMAP,
     )
 
@@ -218,8 +216,6 @@ def update_stacked_bar_plots(
         binarize_threshold=True,
     )
     return figure
-
-    # raise PreventUpdate
 
 
 if __name__ == "__main__":

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -3,7 +3,8 @@
 import os
 
 import dash_mantine_components as dmc
-from dash import Dash
+from dash import Dash, Input, Output, ctx, no_update
+from dash.exceptions import PreventUpdate
 
 from .layout import construct_layout
 
@@ -18,6 +19,37 @@ app = Dash(
 app.layout = dmc.MantineProvider(construct_layout(), forceColorScheme="light")
 
 server = app.server
+
+
+@app.callback(
+    [
+        Output("state-select", "value"),
+        Output("state-select", "disabled"),
+        Output("party-stratify-switch", "checked"),
+        Output("party-stratify-switch", "disabled"),
+    ],
+    [
+        Input("party-stratify-switch", "checked"),
+        Input("state-select", "value"),
+    ],
+    prevent_initial_call=True,
+)
+def disable_state_select_and_party_switch_interaction(
+    is_party_stratify_checked, selected_state
+):
+    """
+    Disable the state dropdown when the party stratify switch is checked,
+    and disable the party stratify switch when a specific state is selected (i.e., not None).
+    """
+    if ctx.triggered_id == "party-stratify-switch":
+        # Deselect any state
+        return None, is_party_stratify_checked, no_update, no_update
+    if ctx.triggered_id == "state-select":
+        if selected_state is not None:
+            return no_update, no_update, False, True
+        return no_update, no_update, False, False
+    return PreventUpdate
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -77,7 +77,7 @@ def update_drawer_state(value):
     Output("drawer-sample-size", "children"),
     [Input("state-select", "value")],
 )
-def updater_drawer_sample_size(value):
+def update_drawer_sample_size(value):
     """Callback function for updating the sample size in the drawer."""
     df = SURVEY_DATA["samplesizes_state.tsv"]
     if value is None:

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -9,6 +9,7 @@ from dash.exceptions import PreventUpdate
 from . import utility as utils
 from .data_loader import NATIONAL_SAMPLE_SIZE, SURVEY_DATA
 from .layout import construct_layout
+from .make_descriptive_plots import make_descriptive_plots
 from .make_map import make_map
 from .utility import (  # IMPACT_COLORMAP,
     DEFAULT_QUESTION,
@@ -90,6 +91,18 @@ def update_drawer_sample_size(value):
     if value is None:
         return f"Sample size: {NATIONAL_SAMPLE_SIZE}"
     return f"Sample size: {df[df['state'] == value]['n'].values[0]}"
+
+
+@callback(
+    Output("sample-descriptive-plot", "figure"),
+    Input("state-select", "value"),
+    prevent_initial_call=True,
+)
+def update_sample_descriptive_plot(state):
+    """Update the sample descriptive plot based on the selected state."""
+    return make_descriptive_plots(
+        state=state,
+    )
 
 
 @callback(

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -10,7 +10,7 @@ from . import utility as utils
 from .data_loader import NATIONAL_SAMPLE_SIZE, SURVEY_DATA
 from .layout import construct_layout
 from .make_map import make_map
-from .utility import (
+from .utility import (  # IMPACT_COLORMAP,
     DEFAULT_QUESTION,
     NO_THRESHOLD_OPTION_VALUE,
     OPINION_COLORMAP,
@@ -119,15 +119,21 @@ def update_map_subtitle(question_value):
     [
         Input("question-select", "value"),
         Input("response-threshold-control", "value"),
+        Input("state-select", "value"),
+        Input("impact-select", "value"),
     ],
     prevent_initial_call=True,
 )
-def update_map_opinion_data(question_value, threshold):
+def update_map(question_value, threshold, state, impact):
     """
     Update the map with the opinion data for the selected question (value encodes a question-subquestion pairing)
     and response threshold, if a threshold is selected.
+
+    Also updates the map with the impact data if a specific impact is selected.
     """
     question, subquestion = utils.extract_question_subquestion(question_value)
+    # TODO: Add logic to display impact data on map with opinion data from *last* selected question
+    # Or, can do this directly in make_map
     if threshold == NO_THRESHOLD_OPTION_VALUE:
         raise PreventUpdate
 
@@ -135,7 +141,12 @@ def update_map_opinion_data(question_value, threshold):
         question=question,
         sub_question=subquestion,
         outcome=threshold,
+        clicked_state=state,
+        impact=impact,
         opinion_colormap=OPINION_COLORMAP,
+        show_impact_as_gradient=False,
+        impact_marker_size_scale=0.6,
+        # impact_colormap=IMPACT_COLORMAP,
     )
 
 

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -128,15 +128,15 @@ def update_map_opinion_data(question_value, threshold):
     and response threshold, if a threshold is selected.
     """
     question, subquestion = utils.extract_question_subquestion(question_value)
-    if threshold != NO_THRESHOLD_OPTION_VALUE:
-        figure = make_map(
-            question=question,
-            sub_question=subquestion,
-            outcome=threshold,
-            opinion_colormap=OPINION_COLORMAP,
-        )
-        return figure
-    raise PreventUpdate
+    if threshold == NO_THRESHOLD_OPTION_VALUE:
+        raise PreventUpdate
+
+    return make_map(
+        question=question,
+        sub_question=subquestion,
+        outcome=threshold,
+        opinion_colormap=OPINION_COLORMAP,
+    )
 
 
 @callback(

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -4,7 +4,6 @@ import os
 
 import dash_mantine_components as dmc
 from dash import Dash, Input, Output, callback, ctx, no_update
-from dash.exceptions import PreventUpdate
 
 from . import utility as utils
 from .data_loader import NATIONAL_SAMPLE_SIZE, SURVEY_DATA
@@ -50,11 +49,10 @@ def disable_state_select_and_party_switch_interaction(
     if ctx.triggered_id == "party-stratify-switch":
         # Deselect any state
         return None, is_party_stratify_checked, no_update, no_update
-    if ctx.triggered_id == "state-select":
-        if selected_state is not None:
-            return no_update, no_update, False, True
-        return no_update, no_update, False, False
-    raise PreventUpdate
+
+    if selected_state is not None:
+        return no_update, no_update, False, True
+    return no_update, no_update, False, False
 
 
 @callback(

--- a/climate_emotions_map/data_loader.py
+++ b/climate_emotions_map/data_loader.py
@@ -92,6 +92,30 @@ def load_geojson_objects() -> dict:
 
 
 SURVEY_DATA = load_survey_data()
+# NOTE: column dtypes for opinions data TSVs
+# Input:
+# df = SURVEY_DATA["opinions_wholesample.tsv"]
+# print(df.dtypes)
+#
+# Output:
+# question         object
+# sub_question     object
+# outcome          object
+# percentage      float64
+# dtype: object
+
 DATA_DICTIONARIES = load_data_dictionaries()
+# NOTE: column dtypes for data dictionary TSVs
+# Input:
+# df = DATA_DICTIONARIES["subquestion_dictionary.tsv"]
+# print(df.dtypes)
+#
+# Output:
+# question        object
+# sub_question    object
+# full_text       object
+# ignore            bool
+# dtype: object
+
 NATIONAL_SAMPLE_SIZE = SURVEY_DATA["samplesizes_state.tsv"]["n"].sum()
 GEOJSON_OBJECTS = load_geojson_objects()

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -4,6 +4,7 @@ import dash_mantine_components as dmc
 from dash import dcc
 
 from . import utility as utils
+from .make_descriptive_plots import make_descriptive_plots
 from .make_map import make_map
 from .utility import (
     DEFAULT_QUESTION,
@@ -96,15 +97,33 @@ def create_drawer_sample_size():
     return dmc.Text(id="drawer-sample-size", size="md")
 
 
+def create_sample_descriptive_plot():
+    """Create the component holding the subplots of sample descriptive statistics."""
+    return dcc.Graph(
+        id="sample-descriptive-plot",
+        figure=make_descriptive_plots(
+            state=None,
+        ),
+        # TODO: Revisit once we've made plot margins smaller (or create a param for this, maybe)
+        # TODO: Fix margins to prevent text from being cut off; make kwargs work
+        style={"height": "90vh"},
+    )
+
+
 def create_sample_description_drawer():
     """Create the toggleable drawer for sample description."""
+    # TODO: Make drawer slide in faster, and remove trap focus (?) so that user can interact with rest of app
     return dmc.Container(
         [
             dmc.Button(
                 "View Sample Description", id="drawer-button", variant="subtle"
             ),
             dmc.Drawer(
-                children=[create_drawer_state(), create_drawer_sample_size()],
+                children=[
+                    create_drawer_state(),
+                    create_drawer_sample_size(),
+                    create_sample_descriptive_plot(),
+                ],
                 title=dmc.Title("Sample Description", order=3, fw=300),
                 id="drawer",
                 padding="md",
@@ -113,6 +132,8 @@ def create_sample_description_drawer():
                     "duration": 550,
                     "timingFunction": "ease",
                 },
+                # TODO: Revisit once plot margins are adjusted
+                size="30%",
             ),
         ]
     )

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -8,9 +8,8 @@ from .make_descriptive_plots import make_descriptive_plots
 from .make_map import make_map
 from .make_stacked_bar_plots import make_stacked_bar
 from .utility import (  # IMPACT_COLORMAP,; OPINION_COLORMAP,
+    DEFAULT_MAP_TITLE,
     DEFAULT_QUESTION,
-    GLOBAL_THRESHOLD_LABELS,
-    NO_THRESHOLD_OPTION_VALUE,
 )
 
 
@@ -49,6 +48,11 @@ def create_state_dropdown():
     )
 
 
+def create_barplot_options_heading():
+    label = dmc.Text("Bar chart options", size="sm", fw=500)
+    return label
+
+
 def create_party_switch():
     """Create the switch for stratifying data by party affiliation."""
     return dmc.Switch(
@@ -59,31 +63,11 @@ def create_party_switch():
 
 
 def create_response_threshold_control():
-    """Create the segmented control for selecting the endorsement threshold to display."""
-    label = dmc.Text(
-        "Display results for responses rated:", size="sm"
-    )  # "response endorsements of"?
-
-    segmented_control = dmc.SegmentedControl(
+    """Create the switch that controls whether to binarize the response data (in stacked bar plots) by an endorsement threshold."""
+    return dmc.Switch(
         id="response-threshold-control",
-        data=[
-            {"label": f"3+ ({GLOBAL_THRESHOLD_LABELS['3+']})", "value": "3+"},
-            {"label": f"4+ ({GLOBAL_THRESHOLD_LABELS['4+']})", "value": "4+"},
-            {
-                "label": "Any endorsement level",
-                "value": NO_THRESHOLD_OPTION_VALUE,
-            },
-        ],
-        # TODO: check if this is needed. It should use the first item in 'data' as the default.
-        # With 'value' set, sometimes it jumps back to the default for no reason?
-        value=DEFAULT_QUESTION["outcome"],
-        orientation="vertical",
-        fullWidth=True,
-    )
-
-    return dmc.Stack(
-        gap=5,
-        children=[label, segmented_control],
+        label="Show all endorsement levels",
+        checked=False,
     )
 
 
@@ -153,6 +137,7 @@ def create_navbar():
             children=[
                 create_question_dropdown(),
                 create_state_dropdown(),
+                create_barplot_options_heading(),
                 create_party_switch(),
                 create_response_threshold_control(),
                 create_sample_description_drawer(),
@@ -204,7 +189,7 @@ def create_question_title():
         children=[
             dmc.Title(
                 id="map-title",
-                children=utils.create_map_title(DEFAULT_QUESTION["outcome"]),
+                children=DEFAULT_MAP_TITLE,
                 order=3,
                 fw=300,
             ),

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -7,11 +7,10 @@ from . import utility as utils
 from .make_descriptive_plots import make_descriptive_plots
 from .make_map import make_map
 from .make_stacked_bar_plots import make_stacked_bar
-from .utility import (
+from .utility import (  # IMPACT_COLORMAP,; OPINION_COLORMAP,
     DEFAULT_QUESTION,
     GLOBAL_THRESHOLD_LABELS,
     NO_THRESHOLD_OPTION_VALUE,
-    OPINION_COLORMAP,
 )
 
 
@@ -249,7 +248,7 @@ def create_map_plot():
                 question=DEFAULT_QUESTION["question"],
                 sub_question=DEFAULT_QUESTION["sub_question"],
                 outcome=DEFAULT_QUESTION["outcome"],
-                opinion_colormap=OPINION_COLORMAP,
+                # opinion_colormap=OPINION_COLORMAP,
             ),
             # vh = % of viewport height
             # TODO: Revisit once plot margins are adjusted

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -96,8 +96,6 @@ def create_sample_descriptive_plot():
 
 def create_sample_description_drawer():
     """Create the toggleable drawer for sample description."""
-    # TODO: Make drawer slide in faster, and remove trap focus (?) so that user can interact with rest of app
-    # TODO: Make "View Sample Description" button also able to close the drawer
     return dmc.Container(
         [
             dmc.Button(

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -1,10 +1,12 @@
 """Generate the layout for the dashboard."""
 
 import dash_mantine_components as dmc
+from dash import dcc
 
 from . import utility as utils
+from .make_map import make_map
 
-DEFAULT_QUESTION = {"question": "q2", "sub_question": 1}
+DEFAULT_QUESTION = {"question": "q2", "sub_question": "1", "outcome": "3+"}
 
 
 def create_question_dropdown():
@@ -166,6 +168,30 @@ def create_question_title():
     )
 
 
+def create_map_plot():
+    """Create the component holding the cloropleth map plot of US states."""
+    # TODO: Ensure that state click events are handled properly
+    us_map = dmc.Container(
+        # TODO: Make map margins smaller (or create a param for this, maybe), and make figure height larger (?)
+        dcc.Graph(
+            id="us-map",
+            figure=make_map(
+                question=DEFAULT_QUESTION["question"],
+                sub_question=DEFAULT_QUESTION["sub_question"],
+                outcome=DEFAULT_QUESTION["outcome"],
+                opinion_colormap="OrRd",
+            ),
+            # vh = % of viewport height
+            # TODO: Revisit once plot margins are adjusted
+            style={"height": "65vh"},
+        ),
+        # sets max width
+        # TODO: Revisit once plot margins are adjusted
+        size="lg",
+    )
+    return us_map
+
+
 def create_main():
     """Create the main content of the dashboard."""
     return dmc.AppShellMain(
@@ -173,8 +199,10 @@ def create_main():
             dmc.Container(
                 my=25,
                 mx="xs",
+                fluid=True,
                 children=[
                     create_question_title(),
+                    create_map_plot(),
                 ],
             )
         ]

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -113,6 +113,7 @@ def create_sample_descriptive_plot():
 def create_sample_description_drawer():
     """Create the toggleable drawer for sample description."""
     # TODO: Make drawer slide in faster, and remove trap focus (?) so that user can interact with rest of app
+    # TODO: Make "View Sample Description" button also able to close the drawer
     return dmc.Container(
         [
             dmc.Button(
@@ -128,12 +129,15 @@ def create_sample_description_drawer():
                 id="drawer",
                 padding="md",
                 transitionProps={
-                    "transition": "slide-right",
+                    "transition": "slide-left",
                     "duration": 550,
                     "timingFunction": "ease",
                 },
-                # TODO: Revisit once plot margins are adjusted
+                # TODO: Revisit size once plot margins are adjusted
                 size="30%",
+                position="right",
+                # Allow user to interact with content in rest of the app when the drawer is open
+                withOverlay=False,
             ),
         ]
     )

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -6,6 +6,7 @@ from dash import dcc
 from . import utility as utils
 from .make_descriptive_plots import make_descriptive_plots
 from .make_map import make_map
+from .make_stacked_bar_plots import make_stacked_bar
 from .utility import (
     DEFAULT_QUESTION,
     GLOBAL_THRESHOLD_LABELS,
@@ -261,6 +262,26 @@ def create_map_plot():
     return us_map
 
 
+def create_stacked_bar_plots():
+    """Create component to hold the stacked bar plot(s) for a subquestion."""
+    figure = dmc.Container(
+        dcc.Graph(
+            id="stacked-bar-plot",
+            figure=make_stacked_bar(
+                question=DEFAULT_QUESTION["question"],
+                subquestion=DEFAULT_QUESTION["sub_question"],
+                state=None,
+                stratify=False,
+                threshold=DEFAULT_QUESTION["outcome"],
+                binarize_threshold=True,
+            ),
+            style={"height": "20vh"},
+        ),
+        size="xl",
+    )
+    return figure
+
+
 def create_main():
     """Create the main content of the dashboard."""
     return dmc.AppShellMain(
@@ -273,6 +294,7 @@ def create_main():
                     create_question_title(),
                     create_impact_dropdown(),
                     create_map_plot(),
+                    create_stacked_bar_plots(),
                 ],
             )
         ]

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -7,10 +7,15 @@ from . import utility as utils
 from .make_map import make_map
 
 DEFAULT_QUESTION = {"question": "q2", "sub_question": "1", "outcome": "3+"}
+NO_THRESHOLD_OPTION_VALUE = "all"
+OPINION_COLORMAP = "OrRd"
 
 
 def create_question_dropdown():
-    """Create the dropdown for subquestions grouped by question."""
+    """
+    Create the dropdown for subquestions grouped by question.
+    NOTE: 'value' must be a string for DMC, so we use f-strings to concatenate the question and subquestion.
+    """
     return dmc.Select(
         id="question-select",
         label="Select a question",  # "Select a sub-question"?
@@ -59,10 +64,16 @@ def create_response_threshold_control():
     segmented_control = dmc.SegmentedControl(
         id="response-threshold-control",
         data=[
-            {"label": "Any endorsement level", "value": "all"},
             {"label": "3+ (moderately and above)", "value": "3+"},
             {"label": "4+ (very much and above)", "value": "4+"},
+            {
+                "label": "Any endorsement level",
+                "value": NO_THRESHOLD_OPTION_VALUE,
+            },
         ],
+        # TODO: check if this is needed. It should use the first item in 'data' as the default.
+        # With 'value' set, sometimes it jumps back to the default for no reason?
+        value=DEFAULT_QUESTION["outcome"],
         orientation="vertical",
         fullWidth=True,
     )
@@ -179,7 +190,7 @@ def create_map_plot():
                 question=DEFAULT_QUESTION["question"],
                 sub_question=DEFAULT_QUESTION["sub_question"],
                 outcome=DEFAULT_QUESTION["outcome"],
-                opinion_colormap="OrRd",
+                opinion_colormap=OPINION_COLORMAP,
             ),
             # vh = % of viewport height
             # TODO: Revisit once plot margins are adjusted

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -196,6 +196,22 @@ def create_question_title():
     )
 
 
+def create_impact_dropdown():
+    """Create the dropdown for selecting the impact to display."""
+    return dmc.Flex(
+        dmc.Select(
+            id="impact-select",
+            label="View distribution of self-reported severe weather event",
+            placeholder="Select a severe weather event",
+            data=utils.get_impact_options(),
+            clearable=True,
+            searchable=True,
+            nothingFoundMessage="No matches",
+        ),
+        justify="flex-end",
+    )
+
+
 def create_map_plot():
     """Create the component holding the cloropleth map plot of US states."""
     # TODO: Ensure that state click events are handled properly
@@ -230,6 +246,7 @@ def create_main():
                 fluid=True,
                 children=[
                     create_question_title(),
+                    create_impact_dropdown(),
                     create_map_plot(),
                 ],
             )

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -5,10 +5,12 @@ from dash import dcc
 
 from . import utility as utils
 from .make_map import make_map
-
-DEFAULT_QUESTION = {"question": "q2", "sub_question": "1", "outcome": "3+"}
-NO_THRESHOLD_OPTION_VALUE = "all"
-OPINION_COLORMAP = "OrRd"
+from .utility import (
+    DEFAULT_QUESTION,
+    GLOBAL_THRESHOLD_LABELS,
+    NO_THRESHOLD_OPTION_VALUE,
+    OPINION_COLORMAP,
+)
 
 
 def create_question_dropdown():
@@ -64,8 +66,8 @@ def create_response_threshold_control():
     segmented_control = dmc.SegmentedControl(
         id="response-threshold-control",
         data=[
-            {"label": "3+ (moderately and above)", "value": "3+"},
-            {"label": "4+ (very much and above)", "value": "4+"},
+            {"label": f"3+ ({GLOBAL_THRESHOLD_LABELS['3+']})", "value": "3+"},
+            {"label": f"4+ ({GLOBAL_THRESHOLD_LABELS['4+']})", "value": "4+"},
             {
                 "label": "Any endorsement level",
                 "value": NO_THRESHOLD_OPTION_VALUE,
@@ -173,9 +175,24 @@ def create_header():
 
 def create_question_title():
     """Create the title for the main content of the dashboard."""
-    # TODO: This will be updated in a callback to reflect the selected question and subquestion.
-    return dmc.Title(
-        "This is the question: This is the subquestion", order=3, fw=300
+    return dmc.Stack(
+        children=[
+            dmc.Title(
+                id="map-title",
+                children=utils.create_map_title(DEFAULT_QUESTION["outcome"]),
+                order=3,
+                fw=300,
+            ),
+            dmc.Text(
+                id="map-subtitle",
+                children=utils.create_question_subtitle(
+                    question=DEFAULT_QUESTION["question"],
+                    subquestion=DEFAULT_QUESTION["sub_question"],
+                ),
+                size="lg",
+            ),
+        ],
+        gap="0",
     )
 
 

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 import pandas as pd
 import plotly.graph_objects as go
-from data_loader import SURVEY_DATA
 from plotly.subplots import make_subplots
+
+from .data_loader import SURVEY_DATA
 
 SAMPLEDESC_WHOLESAMPLE: pd.DataFrame = SURVEY_DATA[
     "sampledesc_wholesample.tsv"

--- a/climate_emotions_map/make_map.py
+++ b/climate_emotions_map/make_map.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import plotly.graph_objects as go
-from data_loader import DATA_DICTIONARIES, GEOJSON_OBJECTS, SURVEY_DATA
+
+from .data_loader import DATA_DICTIONARIES, GEOJSON_OBJECTS, SURVEY_DATA
 
 survey_states = GEOJSON_OBJECTS["survey_states.json"]
 
@@ -52,7 +53,7 @@ def get_state_abbrevs_in_long_format(
 
 def make_map(
     question: str,
-    sub_question: int,
+    sub_question: str,
     outcome: str,
     clicked_state: str | None = None,
     impact: str | None = None,
@@ -68,7 +69,7 @@ def make_map(
     ----------
     question : str
         The question to plot (for opinion data).
-    sub_question : int
+    sub_question : str
         The subquestion to plot (for opinion data).
     outcome : str
         The outcome to plot (for opinion data).
@@ -115,7 +116,7 @@ def make_map(
     # get the question data
     df_opinions = opinions_state.loc[
         (opinions_state["question"] == question)
-        & (opinions_state["sub_question"] == str(sub_question))
+        & (opinions_state["sub_question"] == sub_question)
         & (opinions_state["outcome"] == outcome)
     ]
 
@@ -285,7 +286,7 @@ def make_map(
 
 #     fig = make_map(
 #         question="q2",
-#         sub_question=1,
+#         sub_question="1",
 #         outcome="3+",
 #         clicked_state=clicked_state,
 #         impact="tornado",

--- a/climate_emotions_map/make_stacked_bar_plots.py
+++ b/climate_emotions_map/make_stacked_bar_plots.py
@@ -1,8 +1,7 @@
 import pandas as pd
 import plotly.express as px
 
-# TODO: Use relative import .data_loader
-from data_loader import DATA_DICTIONARIES, SURVEY_DATA
+from .data_loader import DATA_DICTIONARIES, SURVEY_DATA
 
 available_threshold_dict = {"3+": ["1", "2"], "4+": ["1", "2", "3"]}
 
@@ -154,7 +153,7 @@ def get_subquestion_text(question: str, subquestion: str):
     return question_text.values[0]
 
 
-def run(
+def make_stacked_bar(
     question: str,
     subquestion: str,
     state: str | None = None,
@@ -283,7 +282,7 @@ def run(
 
 if __name__ == "__main__":
     # Example run
-    fig = run(
+    fig = make_stacked_bar(
         question="q2",
         subquestion="1",
         state=None,

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -5,6 +5,7 @@ from .data_loader import DATA_DICTIONARIES, SURVEY_DATA
 DEFAULT_QUESTION = {"question": "q2", "sub_question": "1", "outcome": "3+"}
 NO_THRESHOLD_OPTION_VALUE = "all"
 OPINION_COLORMAP = "OrRd"
+# IMPACT_COLORMAP = "magma_r"
 # TODO: Do not hardcode these labels. They should be read from a data dictionary
 GLOBAL_THRESHOLD_LABELS = {
     "3+": "moderately and above",
@@ -82,3 +83,11 @@ def create_question_subtitle(question: str, subquestion: str) -> str:
     q_text = q_df.query(f'question=="{question}"')["full_text"].values[0]
     # TODO: Revisit format for long subquestions - add newline?
     return f'{q_text} "{sq_text}"'
+
+
+def get_impact_options() -> list[dict]:
+    """Get the options for the impact dropdown."""
+    return [
+        {"label": impact, "value": impact}
+        for impact in DATA_DICTIONARIES["impacts_list.tsv"]["impact"]
+    ]

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -3,12 +3,8 @@
 from .data_loader import DATA_DICTIONARIES, SURVEY_DATA
 
 DEFAULT_QUESTION = {"question": "q2", "sub_question": "1", "outcome": "3+"}
-NO_THRESHOLD_OPTION_VALUE = "all"
-# TODO: Do not hardcode these labels. They should be read from a data dictionary
-GLOBAL_THRESHOLD_LABELS = {
-    "3+": "moderately and above",
-    "4+": "very much and above",
-}
+# TODO: Revisit title
+DEFAULT_MAP_TITLE = "Map: Percent (%) of adolescents and young adults who endorse the following question/statement:"
 
 # We have not yet decided on the best colormaps to use
 # OPINION_COLORMAP = "OrRd"
@@ -65,9 +61,12 @@ def extract_question_subquestion(value: str) -> tuple[str, str]:
     return question, sub_question
 
 
-def create_map_title(threshold: str) -> str:
-    """Create a statement for the map title based on the selected threshold."""
-    return f"Estimated % of adolescents and young adults who agree {GLOBAL_THRESHOLD_LABELS[threshold]} with the following:"
+def create_map_title(impact: str = None) -> str:
+    """Create a statement for the map title based on whether a weather impact has been selected."""
+    if impact is None:
+        return DEFAULT_MAP_TITLE
+
+    return f"Map: Percent (%) of adolescents and young adults who reported experiencing the following in the last year: {impact}"
 
 
 def create_question_subtitle(question: str, subquestion: str) -> str:

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -4,13 +4,15 @@ from .data_loader import DATA_DICTIONARIES, SURVEY_DATA
 
 DEFAULT_QUESTION = {"question": "q2", "sub_question": "1", "outcome": "3+"}
 NO_THRESHOLD_OPTION_VALUE = "all"
-OPINION_COLORMAP = "OrRd"
-# IMPACT_COLORMAP = "magma_r"
 # TODO: Do not hardcode these labels. They should be read from a data dictionary
 GLOBAL_THRESHOLD_LABELS = {
     "3+": "moderately and above",
     "4+": "very much and above",
 }
+
+# We have not yet decided on the best colormaps to use
+# OPINION_COLORMAP = "OrRd"
+# IMPACT_COLORMAP = "magma_r"
 
 
 def get_state_options():

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -2,6 +2,15 @@
 
 from .data_loader import DATA_DICTIONARIES, SURVEY_DATA
 
+DEFAULT_QUESTION = {"question": "q2", "sub_question": "1", "outcome": "3+"}
+NO_THRESHOLD_OPTION_VALUE = "all"
+OPINION_COLORMAP = "OrRd"
+# TODO: Do not hardcode these labels. They should be read from a data dictionary
+GLOBAL_THRESHOLD_LABELS = {
+    "3+": "moderately and above",
+    "4+": "very much and above",
+}
+
 
 def get_state_options():
     """Get the options for the state dropdown."""
@@ -51,3 +60,25 @@ def extract_question_subquestion(value: str) -> tuple[str, str]:
     """Extract the question and subquestion from a value in the question dropdown."""
     question, sub_question = value.split("_")
     return question, sub_question
+
+
+def create_map_title(threshold: str) -> str:
+    """Create a statement for the map title based on the selected threshold."""
+    return f"Estimated % of adolescents and young adults who agree {GLOBAL_THRESHOLD_LABELS[threshold]} with the following:"
+
+
+def create_question_subtitle(question: str, subquestion: str) -> str:
+    """Get the full text to display for a question-subquestion pair as the subtitle for the map plot."""
+    q_df = DATA_DICTIONARIES.get("question_dictionary.tsv")
+    sq_df = DATA_DICTIONARIES.get("subquestion_dictionary.tsv")
+
+    sq_text = sq_df.query(
+        f'question=="{question}" & sub_question=="{subquestion}"'
+    )["full_text"].values[0]
+    if sq_df.query(f'question=="{question}"').shape[0] == 1:
+        # If there is only one subquestion, return the subquestion text assuming it is the same as the question text
+        return sq_text
+
+    q_text = q_df.query(f'question=="{question}"')["full_text"].values[0]
+    # TODO: Revisit format for long subquestions - add newline?
+    return f'{q_text} "{sq_text}"'

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -45,3 +45,9 @@ def get_question_options():
         data.append(data_group)
 
     return data
+
+
+def extract_question_subquestion(value: str) -> tuple[str, str]:
+    """Extract the question and subquestion from a value in the question dropdown."""
+    question, sub_question = value.split("_")
+    return question, sub_question


### PR DESCRIPTION
Closes #15 
Closes #23
Closes #36
Closes #35

### Changes proposed in this PR
This PR introduces app interactivity with the stacked bar plot, sample description plot, and basic question stacked bar plot.

- Add title and subtitle to map which are responsive to question & impact selection
- Add impact dropdown to toggle gradient for various weather impacts
- Disable state selection & stratify by party interactivity (since this interaction is not represented in the data)
- Change segmented control for response threshold to simple binary switch
- Make drawer slide in from right (to keep data controls visible), and do not overlay rest of app content when opened