### PR TITLE
[FIX] set React18 via dash_renderer

### DIFF
--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -1,15 +1,13 @@
 """Main file to run the Dash app."""
 
-import os
-
 import dash_mantine_components as dmc
-from dash import Dash, Input, Output, callback, _dash_renderer
+from dash import Dash, Input, Output, _dash_renderer, callback
 
 from .data_loader import NATIONAL_SAMPLE_SIZE, SURVEY_DATA
 from .layout import construct_layout
 
 # Currently needed by DMC, https://www.dash-mantine-components.com/getting-started#simple-usage
-_dash_renderer._set_react_version('18.2.0')
+_dash_renderer._set_react_version("18.2.0")
 
 app = Dash(
     __name__,

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -3,13 +3,13 @@
 import os
 
 import dash_mantine_components as dmc
-from dash import Dash, Input, Output, callback
+from dash import Dash, Input, Output, callback, _dash_renderer
 
 from .data_loader import NATIONAL_SAMPLE_SIZE, SURVEY_DATA
 from .layout import construct_layout
 
 # Currently needed by DMC, https://www.dash-mantine-components.com/getting-started#simple-usage
-os.environ["REACT_VERSION"] = "18.2.0"
+_dash_renderer._set_react_version('18.2.0')
 
 app = Dash(
     __name__,


### PR DESCRIPTION
- replace direct ENV var setting for dash mantine React version with the dash_renderer call

Fixes #39