### PR TITLE
[ENH] Update descriptive plots

### DIFF
--- a/climate_emotions_map/data_loader.py
+++ b/climate_emotions_map/data_loader.py
@@ -63,6 +63,7 @@ def load_survey_data() -> dict[str, pd.DataFrame]:
 def load_data_dictionaries() -> dict[str, pd.DataFrame]:
     """Load the data dictionaries for the survey data."""
     data_files = [
+        "demographics_dictionary.tsv",
         "impacts_list.tsv",
         "outcome_dictionary.tsv",
         "question_dictionary.tsv",

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -118,9 +118,10 @@ def create_sample_descriptive_plot():
         figure=make_descriptive_plots(
             state=None,
         ),
-        # TODO: Revisit once we've made plot margins smaller (or create a param for this, maybe)
-        # TODO: Fix margins to prevent text from being cut off; make kwargs work
-        style={"height": "90vh"},
+        # TODO: Revisit
+        # We use px instead of viewport height here for now to more easily control scrolling
+        # on smaller screens
+        style={"height": "1000px"},
     )
 
 
@@ -151,7 +152,7 @@ def create_sample_description_drawer():
                     "timingFunction": "ease",
                 },
                 # TODO: Revisit size once plot margins are adjusted
-                size="30%",
+                size="40%",
                 position="right",
                 # Allow user to interact with content in rest of the app when the drawer is open
                 withOverlay=False,

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -165,7 +165,9 @@ def get_demographic_variable_to_display(demographic_variable: str):
     return demographic_variable_to_display
 
 
-def get_category_to_display(category: str):
+def get_category_to_display(category: str, demographic_variable: str):
+    if demographic_variable == "student":
+        category = {"yes": "student", "no": "non-student"}[category.lower()]
     return category.capitalize()
 
 
@@ -199,11 +201,15 @@ def make_descriptive_plot_traces(
     bar_plot_trace_without_text = partial(
         go.Bar,
         x=df[COL_PERCENTAGE] * 100,
-        y=df[COL_CATEGORY].apply(get_category_to_display),
+        y=df[COL_CATEGORY].apply(
+            lambda x: get_category_to_display(x, demographic_variable)
+        ),
         customdata=list(
             zip(
                 df[COL_N],
-                df[COL_CATEGORY].apply(get_category_to_display),
+                df[COL_CATEGORY].apply(
+                    lambda x: get_category_to_display(x, demographic_variable)
+                ),
             )
         ),
         orientation="h",
@@ -230,7 +236,9 @@ def make_descriptive_plot_traces(
     traces.append(
         bar_plot_trace_without_text(
             textposition="outside",
-            text=df[COL_CATEGORY].apply(get_category_to_display),
+            text=df[COL_CATEGORY].apply(
+                lambda x: get_category_to_display(x, demographic_variable)
+            ),
             marker_color="rgba(0,0,0,0)",
             hoverinfo="skip",
         )

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -333,8 +333,6 @@ def make_descriptive_plots(
     else:
         data = SAMPLEDESC_STATE.loc[SAMPLEDESC_STATE["state"] == state]
 
-    # vertical_spacing = 0.05
-
     # Number of bars in each subplot
     n_categories = [2, 2, 3, 2, 3, 2, 3, 3, 5, 5, 8]
     # Row heights are specified as a fraction of the total height of the subplot grid
@@ -349,7 +347,6 @@ def make_descriptive_plots(
             get_demographic_variable_to_display(demographic_variable)
             for demographic_variable in SUBPLOT_POSITIONS
         ],
-        # vertical_spacing=vertical_spacing,
     )
 
     if colors is None:

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -312,7 +312,7 @@ def make_descriptive_plots(
     state : str | None, optional
         State/cluster label, by default None (whole sample)
     margins : dict | None, optional
-        Figure margins, by default None ({"l": 0, "r": 0, "t": 20, "b": 0})
+        Figure margins, by default None ({"l": 5, "r": 5, "t": 20, "b": 20})
     text_wrap_width : int, optional
         Maximum width for wrapping some text labels, by default 14
     colors : list[str], optional
@@ -324,7 +324,8 @@ def make_descriptive_plots(
     """
 
     if margins is None:
-        margins = {"l": 0, "r": 0, "t": 20, "b": 0}
+        # NOTE: L/R margins cannot be 0 or else x-axis labels can be cut off on smaller screens
+        margins = {"l": 5, "r": 5, "t": 20, "b": 20}
 
     # get data to plot
     if state is None:
@@ -332,11 +333,12 @@ def make_descriptive_plots(
     else:
         data = SAMPLEDESC_STATE.loc[SAMPLEDESC_STATE["state"] == state]
 
-    vertical_spacing = 0.05
-    row_heights = [
-        n_categories + 0.5 + (vertical_spacing * 2)
-        for n_categories in [2, 2, 3, 2, 3, 2, 3, 3, 5, 5, 8]
-    ]
+    # vertical_spacing = 0.05
+
+    # Number of bars in each subplot
+    n_categories = [2, 2, 3, 2, 3, 2, 3, 3, 5, 5, 8]
+    # Row heights are specified as a fraction of the total height of the subplot grid
+    row_heights = [((1 / sum(n_categories)) * n) for n in n_categories]
 
     # initialize figure
     fig = make_subplots(
@@ -347,7 +349,7 @@ def make_descriptive_plots(
             get_demographic_variable_to_display(demographic_variable)
             for demographic_variable in SUBPLOT_POSITIONS
         ],
-        vertical_spacing=vertical_spacing,
+        # vertical_spacing=vertical_spacing,
     )
 
     if colors is None:

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -122,13 +122,13 @@ SUBPLOT_POSITIONS = {
     "sex": (1, 1),
     "race": (1, 1),
     "ethnicity": (1, 1),
-    "party": (1, 1),
-    "student": (1, 1),
-    "employed": (1, 1),
-    "location": (1, 1),
-    "hh_origin": (1, 1),
-    IMPACTS_LABEL: (4, 1),
-    Q2_LABEL: (5, 1),
+    "party": (1, 2),
+    "student": (1, 2),
+    "employed": (1, 2),
+    "location": (1, 2),
+    "hh_origin": (1, 2),
+    IMPACTS_LABEL: (3, 1),
+    Q2_LABEL: (4, 1),
 }
 
 
@@ -292,27 +292,31 @@ def make_descriptive_plots(state: str | None = None) -> go.Figure:
 
     # initialize figure
     fig = make_subplots(
-        rows=5,
-        cols=1,
+        rows=4,
+        cols=2,
         specs=[
-            [{"rowspan": 3}],
-            [None],
-            [None],
-            [{"rowspan": 1}],
-            [{"rowspan": 1}],
+            [{"rowspan": 2}, {"rowspan": 2}],
+            [None, None],
+            # [None, None],
+            [{"rowspan": 1, "colspan": 2}, None],
+            [{"rowspan": 1, "colspan": 2}, None],
         ],
         subplot_titles=[
             "Demographic information",
+            "More demographic information",
             get_demographic_variable_to_display(IMPACTS_LABEL),
             get_demographic_variable_to_display(Q2_LABEL),
         ],
     )
 
     # add plots
-    demographic_variable_labels = []
+    demographic_variable_labels_by_col = {}
     for demographic_variable in reversed(SUBPLOT_POSITIONS.keys()):
 
         row, col = SUBPLOT_POSITIONS[demographic_variable]
+        if col not in demographic_variable_labels_by_col:
+            demographic_variable_labels_by_col[col] = []
+        demographic_variable_labels = demographic_variable_labels_by_col[col]
 
         if demographic_variable == IMPACTS_LABEL:
             traces = make_impact_plot_traces(data)
@@ -346,7 +350,7 @@ def make_descriptive_plots(state: str | None = None) -> go.Figure:
                 row=row,
                 col=col,
             )
-            fig.update_xaxes(range=[0, 100], row=row, col=col)
+            # fig.update_xaxes(range=[0, 100], row=row, col=col)
 
     fig.update_layout(
         showlegend=False,

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
+from functools import partial
+
 import pandas as pd
 import plotly.graph_objects as go
+from data_loader import DATA_DICTIONARIES, SURVEY_DATA
 from plotly.subplots import make_subplots
 
-from .data_loader import SURVEY_DATA
-
+DEMOGRAPHICS_DICTIONARY = DATA_DICTIONARIES["demographics_dictionary.tsv"]
 SAMPLEDESC_WHOLESAMPLE: pd.DataFrame = SURVEY_DATA[
     "sampledesc_wholesample.tsv"
 ]
@@ -16,7 +18,7 @@ COL_N = "n"
 COL_PERCENTAGE = "percentage"
 
 # special handling of 7 weather impacts
-IMPACTS_LABEL = "impacts"
+IMPACTS_LABEL = "impact"
 IMPACT_VARIABLES = sorted(
     ["drought", "flood", "heat", "hurricane", "smoke", "tornado", "wildfire"]
 )
@@ -113,16 +115,16 @@ CATEGORY_ORDERS.update(
 
 SUBPLOT_POSITIONS = {
     "age": (1, 1),
-    "sex": (1, 3),
-    "party": (1, 5),
-    "race": (2, 1),
-    "ethnicity": (2, 4),
-    "student": (3, 1),
-    "employed": (3, 4),
-    "location": (4, 1),
-    "hh_origin": (4, 4),
-    IMPACTS_LABEL: (5, 1),
-    "q2": (6, 1),
+    "sex": (1, 1),
+    "race": (1, 1),
+    "ethnicity": (1, 1),
+    "party": (1, 1),
+    "student": (1, 1),
+    "employed": (1, 1),
+    "location": (1, 1),
+    "hh_origin": (1, 1),
+    IMPACTS_LABEL: (4, 1),
+    "q2": (5, 1),
 }
 
 
@@ -141,26 +143,24 @@ def get_categories_dict(df: pd.DataFrame) -> dict:
 
 
 def get_demographic_variable_to_display(demographic_variable: str):
-    if demographic_variable == "hh_origin":
-        demographic_variable = "SES of household of origin"
-    elif demographic_variable == "q2":
-        demographic_variable = (
-            "How sure are you that climate change is or is not happening?"
-        )
-    return demographic_variable.capitalize()
+    return (
+        DEMOGRAPHICS_DICTIONARY.set_index(COL_DEMOGRAPHIC_VARIABLE)
+        .loc[demographic_variable]
+        .item()
+    )
 
 
 def get_category_to_display(category: str):
     return category.capitalize()
 
 
-def make_descriptive_plot(
-    df: pd.DataFrame, demographic_variable: str, **kwargs
+def make_descriptive_plot_traces(
+    df: pd.DataFrame,
+    demographic_variable: str,
+    reverse=True,
 ) -> go.Bar:
     """
     Make a single plot for a descriptive demographic variable.
-
-    Extra kwargs are passed to plotly.express.bar()
 
     Parameters
     ----------
@@ -179,25 +179,64 @@ def make_descriptive_plot(
     df[COL_CATEGORY] = pd.Categorical(
         df[COL_CATEGORY], categories=CATEGORY_ORDERS[demographic_variable]
     )
-    df = df.sort_values(COL_CATEGORY)
+    df = df.sort_values(COL_CATEGORY)  # , ascending=not reverse)
 
-    # make the bar plot
-    bar_plot = go.Bar(
-        x=df[COL_CATEGORY].apply(get_category_to_display),
-        y=df[COL_N],
-        customdata=df[COL_PERCENTAGE] * 100,
+    bar_plot_trace_without_text = partial(
+        go.Bar,
+        x=df[COL_PERCENTAGE] * 100,
+        y=(
+            [get_demographic_variable_to_display(demographic_variable)]
+            * len(df[COL_CATEGORY].apply(get_category_to_display))
+        ),
+        hoverinfo="none",
+        customdata=list(
+            zip(
+                df[COL_N],
+                df[COL_CATEGORY].apply(get_category_to_display),
+            )
+        ),
+        orientation="h",
+        # textposition="inside",
         # text=[
         #     f"{n} ({percentage*100:.1f}%)"
         #     for n, percentage in zip(df[COL_N], df[COL_PERCENTAGE])
         # ],
-        hovertemplate=(
-            f"<b>{get_demographic_variable_to_display(demographic_variable)}</b>"
-            "<br>%{x}: %{y} (%{customdata:.1f}%)"
-            "<extra></extra>"
-        ),
+        # hovertemplate=(
+        #     f"<b>{get_demographic_variable_to_display(demographic_variable)}</b>"
+        #     "<br>%{x}: %{y} (%{customdata:.1f}%)"
+        #     "<extra></extra>"
+        # ),
         name=demographic_variable,
+        offsetgroup=0,
     )
-    return bar_plot
+
+    traces = []
+    # make the bar plot
+    traces.append(
+        bar_plot_trace_without_text(
+            textposition="inside",
+            text=[
+                f"{get_category_to_display(category)}: {percentage*100:.1f}% ({n})"
+                for n, percentage, category in zip(
+                    df[COL_N], df[COL_PERCENTAGE], df[COL_CATEGORY]
+                )
+            ],
+            hovertemplate=(
+                # f"<b>{get_demographic_variable_to_display(demographic_variable)}</b>"
+                "<b>%{customdata[1]}</b>: %{x:.2f}% (%{customdata[0]})"
+                "<extra></extra>"
+            ),
+        ),
+    )
+
+    # traces.append(
+    #     bar_plot_trace_without_text(
+    #         textposition="outside",
+    #         text=df[COL_CATEGORY].apply(get_category_to_display),
+    #         marker_color="rgba(0,0,0,0)",
+    #     )
+    # )
+    return traces
 
 
 def make_impact_plot_traces(df: pd.DataFrame):
@@ -209,7 +248,7 @@ def make_impact_plot_traces(df: pd.DataFrame):
     )
     data_impact = data_impact.sort_values(COL_DEMOGRAPHIC_VARIABLE)
     traces = []
-    for category in ["No", "Yes"]:
+    for category in ["Yes"]:
         data_category = data_impact.loc[data_impact[COL_CATEGORY] == category]
         traces.append(
             go.Bar(
@@ -223,6 +262,7 @@ def make_impact_plot_traces(df: pd.DataFrame):
                     f"<br>{category}: %{{y}} (%{{customdata:.1f}}%)"
                     "<extra></extra>"
                 ),
+                constraintext="outside",
                 name=category,
             )
         )
@@ -239,55 +279,85 @@ def make_descriptive_plots(state: str | None = None) -> go.Figure:
 
     # initialize figure
     fig = make_subplots(
-        rows=6,
-        cols=6,
+        rows=5,
+        cols=1,
         specs=[
-            [{"colspan": 2}, None, {"colspan": 2}, None, {"colspan": 2}, None],
-            [{"colspan": 3}, None, None, {"colspan": 3}, None, None],
-            [{"colspan": 3}, None, None, {"colspan": 3}, None, None],
-            [{"colspan": 3}, None, None, {"colspan": 3}, None, None],
-            [{"colspan": 6}, None, None, None, None, None],
-            [{"colspan": 6}, None, None, None, None, None],
+            [{"rowspan": 3}],
+            [None],
+            [None],
+            [{"rowspan": 1}],
+            [{"rowspan": 1}],
+            # [{"colspan": 2}, None, {"colspan": 2}, None, {"colspan": 2}, None],
+            # [{"colspan": 3}, None, None, {"colspan": 3}, None, None],
+            # [{"colspan": 3}, None, None, {"colspan": 3}, None, None],
+            # [{"colspan": 3}, None, None, {"colspan": 3}, None, None],
+            # [{"colspan": 6}, None, None, None, None, None],
+            # [{"colspan": 6}, None, None, None, None, None],
         ],
         subplot_titles=[
-            get_demographic_variable_to_display(demographic_variable)
-            for demographic_variable in SUBPLOT_POSITIONS.keys()
+            "Demographic information",
+            get_demographic_variable_to_display(IMPACTS_LABEL),
+            get_demographic_variable_to_display("q2"),
         ],
+        # subplot_titles=[
+        #     get_demographic_variable_to_display(demographic_variable)
+        #     for demographic_variable in SUBPLOT_POSITIONS.keys()
+        # ],
     )
 
     # add plots
-    for demographic_variable in SUBPLOT_POSITIONS.keys():
+    for demographic_variable in reversed(SUBPLOT_POSITIONS.keys()):
 
         row, col = SUBPLOT_POSITIONS[demographic_variable]
 
         if demographic_variable == IMPACTS_LABEL:
-            for trace in make_impact_plot_traces(data):
-                fig.add_trace(trace, row=row, col=col)
+            traces = make_impact_plot_traces(data)
+            horizontal = False
         else:
-            fig.add_trace(
-                make_descriptive_plot(data, demographic_variable),
+            traces = make_descriptive_plot_traces(data, demographic_variable)
+            horizontal = True
+
+        for trace in traces:
+            fig.add_trace(trace, row=row, col=col)
+
+        if horizontal:
+            fig.update_yaxes(
+                # ticklabelposition="inside",
+                # tickfont={"color": "rgba(0,0,0,0)"},
                 row=row,
                 col=col,
             )
+            fig.update_xaxes(range=[0, 100], row=row, col=col)
+
+    # fig.update_yaxes(
+    #     tickmode="array",
+    #     ticklabelposition="inside",
+    #     tickvals=y,
+    #     ticktext=y,
+    #     row=row,
+    #     col=col,
+    # )
 
     # turn off legend
     fig.update_layout(showlegend=False)
 
+    fig.update_layout(margin={"l": 30, "r": 30, "t": 30, "b": 30})
+
     return fig
 
 
-# if __name__ == "__main__":
+if __name__ == "__main__":
 
-#     # # whole sample
-#     # fig = make_descriptive_plots()
+    # whole sample
+    fig = make_descriptive_plots()
 
-#     # specific state
-#     import numpy as np
+    # # specific state
+    # import numpy as np
 
-#     states: list = SAMPLEDESC_STATE["state"].unique().tolist()
-#     states.append(None)
-#     state = np.random.choice(states)
-#     print(f"state: {state}")
-#     fig = make_descriptive_plots(state=state)
+    # states: list = SAMPLEDESC_STATE["state"].unique().tolist()
+    # states.append(None)
+    # state = np.random.choice(states)
+    # print(f"state: {state}")
+    # fig = make_descriptive_plots(state=state)
 
-#     fig.show()
+    fig.show()

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -383,9 +383,9 @@ def make_descriptive_plots(
                 col=col,
             )
             fig.update_xaxes(
-                range=[0, 105],
+                range=[0, 100],
                 tickvals=[0, 25, 50, 75, 100],
-                ticktext=["0", "25", "50", "75", "100 (%)"],
+                ticktext=["0", "25", "50", "75", "100<br>(%)"],
                 row=row,
                 col=col,
             )

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -254,13 +254,12 @@ def make_impact_plot_traces(df: pd.DataFrame, text_wrap_width=10):
     traces = []
     for category in ["Yes"]:
         data_category = data_impact.loc[data_impact[COL_CATEGORY] == category]
+        x = data_category[COL_DEMOGRAPHIC_VARIABLE].apply(
+            get_demographic_variable_to_display
+        )
         traces.append(
             go.Bar(
-                x=(
-                    data_category[COL_DEMOGRAPHIC_VARIABLE]
-                    .apply(get_demographic_variable_to_display)
-                    .apply(lambda x: wrap_text_label(x, width=text_wrap_width))
-                ),
+                x=x.apply(lambda x: wrap_text_label(x, width=text_wrap_width)),
                 y=data_category[COL_PERCENTAGE] * 100,
                 text=[
                     f"{percentage*100:.1f}% ({n})"
@@ -268,10 +267,10 @@ def make_impact_plot_traces(df: pd.DataFrame, text_wrap_width=10):
                         data_category[COL_PERCENTAGE], data_category[COL_N]
                     )
                 ],
-                customdata=data_category[COL_PERCENTAGE] * 100,
+                customdata=list(zip(x, data_category[COL_N])),
                 hovertemplate=(
-                    "<b>%{x}</b>"
-                    f"<br>{category}: %{{y}} (%{{customdata:.1f}}%)"
+                    "<b>%{customdata[0]}</b>"
+                    ": %{y:.2f}% (%{customdata[1]})"
                     "<extra></extra>"
                 ),
                 hoverinfo="none",

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -133,17 +133,6 @@ SUBPLOT_POSITIONS = {
     "hh_origin": (9, 1),
     IMPACTS_LABEL: (10, 1),
     Q2_LABEL: (11, 1),
-    # "age": (1, 1),
-    # "sex": (3, 1),
-    # "race": (5, 1),
-    # "ethnicity": (8, 1),
-    # "party": (10, 1),
-    # "student": (13, 1),
-    # "employed": (15, 1),
-    # "location": (18, 1),
-    # "hh_origin": (21, 1),
-    # IMPACTS_LABEL: (26, 1),
-    # Q2_LABEL: (30, 1),
 }
 
 
@@ -210,12 +199,7 @@ def make_descriptive_plot_traces(
     bar_plot_trace_without_text = partial(
         go.Bar,
         x=df[COL_PERCENTAGE] * 100,
-        # y=(
-        #     [get_demographic_variable_to_display(demographic_variable)]
-        #     * len(df[COL_CATEGORY].apply(get_category_to_display))
-        # ),
         y=df[COL_CATEGORY].apply(get_category_to_display),
-        # hoverinfo="none",
         customdata=list(
             zip(
                 df[COL_N],
@@ -237,7 +221,6 @@ def make_descriptive_plot_traces(
                 for n, percentage in zip(df[COL_N], df[COL_PERCENTAGE])
             ],
             hovertemplate=(
-                # f"<b>{get_demographic_variable_to_display(demographic_variable)}</b>"
                 "<b>%{customdata[1]}</b>: %{x:.2f}% (%{customdata[0]})"
                 "<extra></extra>"
             ),
@@ -318,53 +301,9 @@ def make_descriptive_plots(
 
     # initialize figure
     fig = make_subplots(
-        # rows=36,
         rows=len(row_heights),
         cols=1,
         row_heights=row_heights,
-        # specs=[
-        #     [{"rowspan": 2}],
-        #     [None],
-        #     [{"rowspan": 2}],
-        #     [None],
-        #     [{"rowspan": 3}],
-        #     [None],
-        #     [None],
-        #     [{"rowspan": 2}],
-        #     [None],
-        #     [{"rowspan": 3}],
-        #     [None],
-        #     [None],
-        #     [{"rowspan": 2}],
-        #     [None],
-        #     [{"rowspan": 3}],
-        #     [None],
-        #     [None],
-        #     [{"rowspan": 3}],
-        #     [None],
-        #     [None],
-        #     [{"rowspan": 5}],
-        #     [None],
-        #     [None],
-        #     [None],
-        #     [None],
-        #     [{"rowspan": 4}],
-        #     [None],
-        #     [None],
-        #     [None],
-        #     [{"rowspan": 7}],
-        #     [None],
-        #     [None],
-        #     [None],
-        #     [None],
-        #     [None],
-        #     [None],
-        # ],
-        # subplot_titles=[
-        #     "Demographic information",
-        #     get_demographic_variable_to_display(IMPACTS_LABEL),
-        #     get_demographic_variable_to_display(Q2_LABEL),
-        # ],
         subplot_titles=[
             get_demographic_variable_to_display(demographic_variable)
             for demographic_variable in SUBPLOT_POSITIONS
@@ -397,19 +336,7 @@ def make_descriptive_plots(
         if not demographic_variable == IMPACTS_LABEL:
             tickvals = ["" for _ in CATEGORY_ORDERS[demographic_variable]]
             ticktext = tickvals
-            # if demographic_variable == Q2_LABEL:
-            #     tickvals = ["" for _ in CATEGORY_ORDERS[demographic_variable]]
-            #     ticktext = tickvals
-            # else:
-            #     df_y_ticks = pd.DataFrame(demographic_variable_labels)
-            #     df_y_ticks = (
-            #         df_y_ticks.reset_index().groupby(0).mean().reset_index()
-            #     )
-            #     # print(df_y_ticks)
-            #     tickvals = df_y_ticks["index"]
-            #     ticktext = df_y_ticks[0].apply(
-            #         get_demographic_variable_to_display
-            #     )
+
             fig.update_yaxes(
                 tickvals=tickvals,
                 ticktext=ticktext,
@@ -425,17 +352,6 @@ def make_descriptive_plots(
             )
             fig.update_layout(bargap=0)
 
-            # # # fig.update_annotations(dict(text="%", x=50, y=1), row=row, col=col)
-            # fig.add_annotation(
-            #     x=99,
-            #     y=-0.5,
-            #     text="(%)",
-            #     ax=0,
-            #     ay=0,
-            #     font=dict(size=10),
-            #     row=row,
-            #     col=col,
-            # )
         else:
             fig.update_yaxes(
                 range=[0, 100],

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -158,10 +158,10 @@ def get_demographic_variable_to_display(demographic_variable: str):
     )
     if demographic_variable in DEMOGRAPHIC_VARIABLES_WITH_ASTERISK:
         demographic_variable_to_display = f"{demographic_variable_to_display}*"
-    if demographic_variable == Q2_LABEL:
-        demographic_variable_to_display = wrap_text_label(
-            demographic_variable_to_display, width=38
-        )
+    # if demographic_variable == Q2_LABEL:
+    #     demographic_variable_to_display = wrap_text_label(
+    #         demographic_variable_to_display, width=38
+    #     )
     return demographic_variable_to_display
 
 
@@ -222,10 +222,10 @@ def make_descriptive_plot_traces(
     traces.append(
         bar_plot_trace_without_text(
             textposition="inside",
-            text=[
-                f"{percentage*100:.1f}% ({n})"
-                for n, percentage in zip(df[COL_N], df[COL_PERCENTAGE])
-            ],
+            # text=[
+            #     f"{percentage*100:.1f}% ({n})"
+            #     for n, percentage in zip(df[COL_N], df[COL_PERCENTAGE])
+            # ],
             hovertemplate=(
                 "<b>%{customdata[1]}</b>: %{x:.2f}% (%{customdata[0]})"
                 "<extra></extra>"
@@ -269,12 +269,15 @@ def make_impact_plot_traces(df: pd.DataFrame, text_wrap_width=10):
             go.Bar(
                 x=x.apply(lambda x: wrap_text_label(x, width=text_wrap_width)),
                 y=data_category[COL_PERCENTAGE] * 100,
-                text=[
-                    f"{percentage*100:.1f}% ({n})"
-                    for percentage, n in zip(
-                        data_category[COL_PERCENTAGE], data_category[COL_N]
-                    )
-                ],
+                # text=[
+                #     f"{percentage*100:.1f}% ({n})"
+                #     for percentage, n in zip(
+                #         data_category[COL_PERCENTAGE], data_category[COL_N]
+                #     )
+                # ],
+                text=x.apply(
+                    lambda x: wrap_text_label(x, width=text_wrap_width)
+                ),
                 customdata=list(zip(x, data_category[COL_N])),
                 hovertemplate=(
                     "<b>%{customdata[0]}</b>"
@@ -289,7 +292,7 @@ def make_impact_plot_traces(df: pd.DataFrame, text_wrap_width=10):
 
 
 def make_descriptive_plots(
-    state: str | None = None, margins=None, text_wrap_width=13
+    state: str | None = None, margins=None, text_wrap_width=14
 ) -> go.Figure:
 
     if margins is None:
@@ -367,6 +370,12 @@ def make_descriptive_plots(
                 row=row,
                 col=col,
             )
+            fig.update_xaxes(
+                tickvals=[],
+                ticktext=[],
+                row=row,
+                col=col,
+            )
 
         fig.update_yaxes(
             tickfont=dict(size=10),
@@ -383,10 +392,7 @@ def make_descriptive_plots(
         showlegend=False,
         margin=margins,
         template="plotly_white",
-        # autosize=False,
-        # height=1000,
-        # width=500,
-        font=dict(size=12),
+        font=dict(size=10),
     )
     fig.update_annotations(font_size=12)
 

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -243,7 +243,7 @@ def wrap_df_column_values(series: pd.Series, width: int) -> pd.DataFrame:
     return series
 
 
-def make_impact_plot_traces(df: pd.DataFrame):
+def make_impact_plot_traces(df: pd.DataFrame, text_wrap_width=15):
     data_impact = df.loc[
         df[COL_DEMOGRAPHIC_VARIABLE].isin(IMPACT_VARIABLES)
     ].copy()
@@ -260,7 +260,7 @@ def make_impact_plot_traces(df: pd.DataFrame):
                     data_category[COL_DEMOGRAPHIC_VARIABLE].apply(
                         get_demographic_variable_to_display
                     ),
-                    width=15,
+                    width=text_wrap_width,
                 ),
                 y=data_category[COL_PERCENTAGE] * 100,
                 text=[
@@ -282,7 +282,12 @@ def make_impact_plot_traces(df: pd.DataFrame):
     return traces
 
 
-def make_descriptive_plots(state: str | None = None) -> go.Figure:
+def make_descriptive_plots(
+    state: str | None = None, margins=None, text_wrap_width=15
+) -> go.Figure:
+
+    if margins is None:
+        margins = {"l": 0, "r": 0, "t": 20, "b": 0}
 
     # get data to plot
     if state is None:
@@ -315,7 +320,9 @@ def make_descriptive_plots(state: str | None = None) -> go.Figure:
         row, col = SUBPLOT_POSITIONS[demographic_variable]
 
         if demographic_variable == IMPACTS_LABEL:
-            traces = make_impact_plot_traces(data)
+            traces = make_impact_plot_traces(
+                data, text_wrap_width=text_wrap_width
+            )
         else:
             traces = make_descriptive_plot_traces(data, demographic_variable)
             if demographic_variable != Q2_LABEL:
@@ -350,7 +357,7 @@ def make_descriptive_plots(state: str | None = None) -> go.Figure:
 
     fig.update_layout(
         showlegend=False,
-        margin={"l": 0, "r": 0, "t": 20, "b": 0},
+        margin=margins,
     )
 
     return fig

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -161,10 +161,10 @@ def get_demographic_variable_to_display(demographic_variable: str):
     )
     if demographic_variable in DEMOGRAPHIC_VARIABLES_WITH_ASTERISK:
         demographic_variable_to_display = f"{demographic_variable_to_display}*"
-    # if demographic_variable == Q2_LABEL:
-    #     demographic_variable_to_display = wrap_text_label(
-    #         demographic_variable_to_display, width=38
-    #     )
+    if demographic_variable == Q2_LABEL:
+        demographic_variable_to_display = wrap_text_label(
+            demographic_variable_to_display, width=40
+        )
     return demographic_variable_to_display
 
 

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -122,13 +122,13 @@ SUBPLOT_POSITIONS = {
     "sex": (1, 1),
     "race": (1, 1),
     "ethnicity": (1, 1),
-    "party": (1, 2),
-    "student": (1, 2),
-    "employed": (1, 2),
-    "location": (1, 2),
-    "hh_origin": (1, 2),
-    IMPACTS_LABEL: (3, 1),
-    Q2_LABEL: (4, 1),
+    "party": (1, 1),
+    "student": (1, 1),
+    "employed": (1, 1),
+    "location": (1, 1),
+    "hh_origin": (1, 1),
+    IMPACTS_LABEL: (4, 1),
+    Q2_LABEL: (5, 1),
 }
 
 
@@ -292,31 +292,27 @@ def make_descriptive_plots(state: str | None = None) -> go.Figure:
 
     # initialize figure
     fig = make_subplots(
-        rows=4,
-        cols=2,
+        rows=5,
+        cols=1,
         specs=[
-            [{"rowspan": 2}, {"rowspan": 2}],
-            [None, None],
-            # [None, None],
-            [{"rowspan": 1, "colspan": 2}, None],
-            [{"rowspan": 1, "colspan": 2}, None],
+            [{"rowspan": 3}],
+            [None],
+            [None],
+            [{"rowspan": 1}],
+            [{"rowspan": 1}],
         ],
         subplot_titles=[
             "Demographic information",
-            "More demographic information",
             get_demographic_variable_to_display(IMPACTS_LABEL),
             get_demographic_variable_to_display(Q2_LABEL),
         ],
     )
 
     # add plots
-    demographic_variable_labels_by_col = {}
+    demographic_variable_labels = []
     for demographic_variable in reversed(SUBPLOT_POSITIONS.keys()):
 
         row, col = SUBPLOT_POSITIONS[demographic_variable]
-        if col not in demographic_variable_labels_by_col:
-            demographic_variable_labels_by_col[col] = []
-        demographic_variable_labels = demographic_variable_labels_by_col[col]
 
         if demographic_variable == IMPACTS_LABEL:
             traces = make_impact_plot_traces(data)
@@ -350,7 +346,7 @@ def make_descriptive_plots(state: str | None = None) -> go.Figure:
                 row=row,
                 col=col,
             )
-            # fig.update_xaxes(range=[0, 100], row=row, col=col)
+            fig.update_xaxes(range=[0, 100], row=row, col=col)
 
     fig.update_layout(
         showlegend=False,


### PR DESCRIPTION
Closes #25.

Screenshot: 
![Screenshot 2024-06-02 at 5 07 52 PM](https://github.com/neurodatascience/us_climate_emotions_map/assets/29051929/3364228c-1c20-46e4-9130-102cda15ae0e)

Regarding the text inside the horizontal barplots (percentage/count) looks, I feel like it's too small and makes things a bit crowded. Also, when the bar is small (e.g. "Upper class" in "SES of household of origin"), the text is cut and since the hoverboxes are disabled then that just means the information is not visible/accessible. So my preferred visualization would be to only show the percentage+count values in hoverboxes (for both the "Demographic information" and the "How sure are you that climate change is or is not happening?" plots), but curious to hear what others think.

I have also tried alternative visualizations that don't match to what we had discussed, just to see what they would look like. Attaching screenshots but note that some parts (spacing/labels) are rough.

(with 2 horizontal bar plots for the demographics instead of 1)
![Screenshot 2024-06-02 at 5 15 21 PM](https://github.com/neurodatascience/us_climate_emotions_map/assets/29051929/a30fa864-f0fe-4a91-9c13-c1931021dd19)

(with stacked bar plots for the demographics (ignore the Q2 plot which does not look good))
![Screenshot 2024-06-02 at 4 30 34 PM](https://github.com/neurodatascience/us_climate_emotions_map/assets/29051929/9364d246-5865-451c-80b0-c8f4c60ccc52)

Also, not sure how we want to do the colour schema thing but I don't think that would be very hard (as long as I don't have to decide on the colours...)