### PR TITLE
[ENH] Update map graphic

### DIFF
--- a/climate_emotions_map/make_map.py
+++ b/climate_emotions_map/make_map.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import plotly.graph_objects as go
-from data_loader import DATA_DICTIONARIES, GEOJSON_OBJECTS, SURVEY_DATA
+
+from .data_loader import DATA_DICTIONARIES, GEOJSON_OBJECTS, SURVEY_DATA
 
 survey_states = GEOJSON_OBJECTS["survey_states.json"]
 
@@ -58,7 +59,7 @@ def make_map(
     impact: str | None = None,
     show_impact_as_gradient=True,
     opinion_colormap: str | None = "Greens",
-    impact_colormap: str | None = "Oranges",
+    impact_colormap: str | None = "OrRd",
     clicked_state_marker: dict | None = None,
     impact_marker_size_scale: float = 1.0,
     colormap_range_padding=10,

--- a/climate_emotions_map/make_map.py
+++ b/climate_emotions_map/make_map.py
@@ -58,7 +58,7 @@ def make_map(
     clicked_state: str | None = None,
     impact: str | None = None,
     show_impact_as_gradient=True,
-    opinion_colormap: str | None = "Greens",
+    opinion_colormap: str | None = None,
     impact_colormap: str | None = "OrRd",
     clicked_state_marker: dict | None = None,
     impact_marker_size_scale: float = 1.0,
@@ -112,6 +112,14 @@ def make_map(
     col_color_impact = f"{col_color} (impact)"
 
     # default values
+    if opinion_colormap is None:
+        opinion_colormap = [
+            "#FAE776",
+            "#F9C74F",
+            "#F8961E",
+            "#F3722C",
+            "#F94144",
+        ]
     if clicked_state_marker is None:
         clicked_state_marker = dict(line=dict(width=4, color="#2a3f5f"))
     if margins is None:

--- a/climate_emotions_map/make_map.py
+++ b/climate_emotions_map/make_map.py
@@ -113,7 +113,7 @@ def make_map(
 
     # default values
     if clicked_state_marker is None:
-        clicked_state_marker = dict(line=dict(width=4, color="yellow"))
+        clicked_state_marker = dict(line=dict(width=4, color="#2a3f5f"))
     if margins is None:
         margins = {"l": 30, "r": 30, "t": 30, "b": 30}
 
@@ -262,7 +262,10 @@ def make_map(
     fig.add_scattergeo(
         locations=state_abbrevs_long["state_abbreviated"],
         locationmode="USA-states",
-        text=state_abbrevs_long["state_abbreviated"],
+        text=[
+            f"<b>{abbr}</b>"
+            for abbr in state_abbrevs_long["state_abbreviated"]
+        ],
         mode="text",
         hoverinfo="skip",
         name="abbr_labels",

--- a/climate_emotions_map/make_map.py
+++ b/climate_emotions_map/make_map.py
@@ -62,8 +62,8 @@ def make_map(
     impact_colormap: str | None = "OrRd",
     clicked_state_marker: dict | None = None,
     impact_marker_size_scale: float = 1.0,
-    colormap_range_padding=10,
-    margins=None,
+    colormap_range_padding: int = 10,
+    margins: dict = None,
 ) -> go.Figure:
     """Generate choropleth map showing opinion and/or impact data.
 
@@ -82,13 +82,13 @@ def make_map(
     show_impact_as_gradient : bool, optional
         Whether to show impact information in the base map (replacing opinion
         data) instead of as an additional scatter plot, by default True
-    opinion_colormap : str | None, optional
-        Colormap for the opinion data, by default "Greens"
+    opinion_colormap : str | list | None, optional
+        Colormap for the opinion data
     impact_colormap : str | None, optional
-        Colormap for the impact data, by default "Oranges"
+        Colormap for the impact data, by default "OrRd"
     clicked_state_marker : dict | None, optional
         Configuration for the clicked state (e.g., highlighting color). By
-        default it will make the outline thicker and yellow
+        default it will make the outline thicker and navy (#2a3f5f)
     impact_marker_size_scale : float, optional
         Scale factor for the impact marker size, by default 1.0
     colormap_range_padding : int, optional
@@ -270,10 +270,7 @@ def make_map(
     fig.add_scattergeo(
         locations=state_abbrevs_long["state_abbreviated"],
         locationmode="USA-states",
-        text=[
-            f"<b>{abbr}</b>"
-            for abbr in state_abbrevs_long["state_abbreviated"]
-        ],
+        text=state_abbrevs_long["state_abbreviated"].apply(lambda abbr: f"<b>{abbr}</b>"),
         mode="text",
         hoverinfo="skip",
         name="abbr_labels",

--- a/climate_emotions_map/make_map.py
+++ b/climate_emotions_map/make_map.py
@@ -229,7 +229,7 @@ def make_map(
     if impact is not None and not show_impact_as_gradient:
         customdata_cols.append(col_color_impact)
         hovertemplate_extra = (
-            f"<br>{col_color_impact.capitalize()}: %{{customdata[2]:.2f}}"
+            f"<br>{col_color_impact.capitalize()}: %{{customdata[2]:.1f}}%"
         )
     fig.add_choropleth(
         locations=df_hover_data["state_abbreviated"],
@@ -241,7 +241,7 @@ def make_map(
         hovertemplate=(
             "<b>%{customdata[0]}</b>"
             "<br>Sample size: %{customdata[1]}"
-            f"<br>{col_gradient.capitalize()}: %{{z:.2f}}"
+            f"<br>{col_gradient.capitalize()}: %{{z:.1f}}%"
             f"{hovertemplate_extra}"
             "<extra></extra>"
         ),
@@ -270,7 +270,9 @@ def make_map(
     fig.add_scattergeo(
         locations=state_abbrevs_long["state_abbreviated"],
         locationmode="USA-states",
-        text=state_abbrevs_long["state_abbreviated"].apply(lambda abbr: f"<b>{abbr}</b>"),
+        text=state_abbrevs_long["state_abbreviated"].apply(
+            lambda abbr: f"<b>{abbr}</b>"
+        ),
         mode="text",
         hoverinfo="skip",
         name="abbr_labels",


### PR DESCRIPTION
Closes #26.

Summary:
- Picked 2 built-in colormaps, tried to avoid red/blue colours to avoid associations with political parties
  - `"Greens"` for opinions and `"Oranges"` for impacts
  - This was pretty arbitrary, and the colours might not play well with the stacked bar plots below the map graphic, so if @koudyk or others have better ideas please share them
- Added the +/- 10% padding for vmin/vmax
  - At the last meeting we tried forcing a consistent 0-100 and that doesn't work well at all because most questions do not span that entire range
- Added the margins as @alyssadai suggested

Screenshot for opinion:
![Screenshot 2024-06-02 at 6 20 28 PM](https://github.com/neurodatascience/us_climate_emotions_map/assets/29051929/d9483508-3c40-4ce3-bb33-2851c54e8b48)

Screenshot for weather impact:
![Screenshot 2024-06-02 at 6 20 52 PM](https://github.com/neurodatascience/us_climate_emotions_map/assets/29051929/b1c299cc-af21-4a51-9817-509c3ac75738)

