### PR TITLE
[MNT] Update minimum ver. of Dash required

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+dash>=2.17.0
 dash[testing]
 dash-mantine-components
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,16 +17,22 @@ certifi==2024.2.2
     #   requests
     #   urllib3
 cffi==1.16.0
-    # via cryptography
+    # via
+    #   cryptography
+    #   trio
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via flask
+colorama==0.4.6
+    # via
+    #   click
+    #   pytest
 cryptography==42.0.5
     # via
     #   pyopenssl
     #   urllib3
-dash==2.16.1
+dash==2.17.0
     # via -r requirements.in
 dash-core-components==2.0.0
     # via dash


### PR DESCRIPTION
- We want to use the new `overlay_style` param for the dcc.Loading spinner component (see https://github.com/plotly/dash/releases/tag/v2.17.0)
- Dependencies updated following https://github.com/neurodatascience/us_climate_emotions_map/blob/main/CONTRIBUTING.md#updating-requirements