### PR TITLE
[ENH] Add stacked bar charts for all questions organized in domain tabs

### DIFF
--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -2,6 +2,7 @@
 
 import dash_mantine_components as dmc
 from dash import (
+    ALL,
     Dash,
     Input,
     Output,
@@ -173,9 +174,8 @@ def update_map(question_value, state, impact):
 
 
 @callback(
-    Output("stacked-bar-plot", "figure"),
+    Output({"type": "stacked-bar-plot", "question": ALL}, "figure"),
     [
-        Input("question-select", "value"),
         Input("state-select", "value"),
         Input("party-stratify-switch", "checked"),
         Input("response-threshold-control", "checked"),
@@ -183,28 +183,31 @@ def update_map(question_value, state, impact):
     prevent_initial_call=True,
 )
 def update_stacked_bar_plots(
-    question_value,
     state,
     is_party_stratify_checked,
     show_all_responses_checked,
 ):
-    """Update the stacked bar plots based on the selected question."""
-    question, subquestion = utils.extract_question_subquestion(question_value)
+    """Update the stacked bar plots for all questions based on the selected criteria."""
+    figures = []
+    for output in ctx.outputs_list:
+        # Example: {'id': {'question': 'q2', 'type': 'stacked-bar-plot'}, 'property': 'figure'}
+        question = output["id"]["question"]
 
-    if show_all_responses_checked:
-        threshold = None
-    elif not show_all_responses_checked:
-        threshold = DEFAULT_QUESTION["outcome"]
+        if show_all_responses_checked:
+            threshold = None
+        elif not show_all_responses_checked:
+            threshold = DEFAULT_QUESTION["outcome"]
 
-    figure = make_stacked_bar(
-        question=question,
-        subquestion=subquestion,
-        state=state,
-        stratify=is_party_stratify_checked,
-        threshold=threshold,
-        binarize_threshold=True,
-    )
-    return figure
+        figure = make_stacked_bar(
+            question=question,
+            subquestion="all",
+            state=state,
+            stratify=is_party_stratify_checked,
+            threshold=threshold,
+        )
+        figures.append(figure)
+
+    return figures
 
 
 if __name__ == "__main__":

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -12,6 +12,7 @@ from dash import (
     ctx,
     no_update,
 )
+from dash.exceptions import PreventUpdate
 
 from . import utility as utils
 from .data_loader import NATIONAL_SAMPLE_SIZE, SURVEY_DATA
@@ -54,16 +55,20 @@ def update_state_and_disable_state_select_and_party_switch_interaction(
     figure, is_party_stratify_checked, selected_state
 ):
     """
-    Update the state dropdown when a specific state is clicked,
-    Disable the state dropdown when the party stratify switch is checked,
+    Update the state dropdown when a specific state is clicked (if party stratify switch is not checked),
+    disable the state dropdown when the party stratify switch is checked,
     and disable the party stratify switch when a specific state is selected (i.e., not None).
     """
-    if figure:
+    if ctx.triggered_id == "us-map":
+        map_selected_state = figure["points"][0]["customdata"][0]
+
+        if is_party_stratify_checked or map_selected_state == selected_state:
+            raise PreventUpdate
         return (
-            figure["points"][0]["customdata"][0],
+            map_selected_state,
             no_update,
-            no_update,
-            no_update,
+            False,
+            True,
         )
     if ctx.triggered_id == "party-stratify-switch":
         # Deselect any state

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -20,9 +20,11 @@ from .layout import SINGLE_SUBQUESTION_FIG_KW, construct_layout
 from .make_descriptive_plots import make_descriptive_plots
 from .make_map import make_map
 from .make_stacked_bar_plots import make_stacked_bar
-from .utility import DEFAULT_QUESTION  # IMPACT_COLORMAP,; OPINION_COLORMAP,
-
-ALL_STATES_LABEL = "National"
+from .utility import (  # IMPACT_COLORMAP,; OPINION_COLORMAP,
+    ALL_STATES_LABEL,
+    DEFAULT_QUESTION,
+    SECTION_TITLES,
+)
 
 # Currently needed by DMC, https://www.dash-mantine-components.com/getting-started#simple-usage
 _dash_renderer._set_react_version("18.2.0")
@@ -232,8 +234,8 @@ def update_selected_question_bar_plot(
 def update_selected_question_title(state):
     """Update the title for the selected question based on the selected state."""
     if state is None:
-        return f"Response distribution, {ALL_STATES_LABEL}"
-    return f"Response distribution, {state}"
+        return f"{SECTION_TITLES['selected_question']}, {ALL_STATES_LABEL}"
+    return f"{SECTION_TITLES['selected_question']}, {state}"
 
 
 @callback(
@@ -246,6 +248,17 @@ def toggle_selected_question_bar_plot_visibility(impact):
     if impact is not None:
         return "none"
     return "flex"
+
+
+@callback(
+    Output("all-questions-title", "children"),
+    Input("state-select", "value"),
+)
+def update_all_questions_title(state):
+    """Update the title for the section for all questions based on the selected state."""
+    if state is None:
+        return f"{SECTION_TITLES['all_questions']}, {ALL_STATES_LABEL}"
+    return f"{SECTION_TITLES['all_questions']}, {state}"
 
 
 @callback(

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -237,6 +237,18 @@ def update_selected_question_title(state):
 
 
 @callback(
+    Output("selected-question-container", "display"),
+    Input("impact-select", "value"),
+    prevent_initial_call=True,
+)
+def toggle_selected_question_bar_plot_visibility(impact):
+    """Toggle visibility of the selected question bar plot component based on whether an impact is selected."""
+    if impact is not None:
+        return "none"
+    return "flex"
+
+
+@callback(
     Output({"type": "stacked-bar-plot", "question": ALL}, "figure"),
     [
         Input("state-select", "value"),

--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -44,18 +44,27 @@ server = app.server
         Output("party-stratify-switch", "disabled"),
     ],
     [
+        Input("us-map", "clickData"),
         Input("party-stratify-switch", "checked"),
         Input("state-select", "value"),
     ],
     prevent_initial_call=True,
 )
-def disable_state_select_and_party_switch_interaction(
-    is_party_stratify_checked, selected_state
+def update_state_and_disable_state_select_and_party_switch_interaction(
+    figure, is_party_stratify_checked, selected_state
 ):
     """
+    Update the state dropdown when a specific state is clicked,
     Disable the state dropdown when the party stratify switch is checked,
     and disable the party stratify switch when a specific state is selected (i.e., not None).
     """
+    if figure:
+        return (
+            figure["points"][0]["customdata"][0],
+            no_update,
+            no_update,
+            no_update,
+        )
     if ctx.triggered_id == "party-stratify-switch":
         # Deselect any state
         return None, is_party_stratify_checked, no_update, no_update

--- a/climate_emotions_map/data_loader.py
+++ b/climate_emotions_map/data_loader.py
@@ -117,6 +117,13 @@ def get_subquestion_order():
     return subquestion_order
 
 
+def get_domain_text() -> dict[str, str]:
+    """Return a dictionary where key-value pairs are short and full names of each available domain."""
+    df = DATA_DICTIONARIES["question_dictionary.tsv"]
+    df_unique = df[["domain_short", "domain_text"]].drop_duplicates()
+    return dict(zip(df_unique["domain_short"], df_unique["domain_text"]))
+
+
 SURVEY_DATA = load_survey_data()
 # NOTE: column dtypes for opinions data TSVs
 # Input:
@@ -144,14 +151,7 @@ DATA_DICTIONARIES = load_data_dictionaries()
 # ignore            bool
 # dtype: object
 
-# TODO: Extract from updated question data dictionary
-DOMAIN_TEXT = {
-    "Climate emotions & beliefs": "Emotions & beliefs about climate change",
-    "Responses to climate emotions": "Response to emotions about climate change",
-    "Responsibility perceptions": "Responsibility for climate climate change",
-    "Desired and planned actions": "Desired and planned actions",
-    "Views on government response": "Emotions and beliefs about US Government response to climate change",
-}
+DOMAIN_TEXT = get_domain_text()
 
 NATIONAL_SAMPLE_SIZE = SURVEY_DATA["samplesizes_state.tsv"]["n"].sum()
 GEOJSON_OBJECTS = load_geojson_objects()

--- a/climate_emotions_map/data_loader.py
+++ b/climate_emotions_map/data_loader.py
@@ -144,5 +144,14 @@ DATA_DICTIONARIES = load_data_dictionaries()
 # ignore            bool
 # dtype: object
 
+# TODO: Extract from updated question data dictionary
+DOMAIN_TEXT = {
+    "Climate emotions & beliefs": "Emotions & beliefs about climate change",
+    "Responses to climate emotions": "Response to emotions about climate change",
+    "Responsibility perceptions": "Responsibility for climate climate change",
+    "Desired and planned actions": "Desired and planned actions",
+    "Views on government response": "Emotions and beliefs about US Government response to climate change",
+}
+
 NATIONAL_SAMPLE_SIZE = SURVEY_DATA["samplesizes_state.tsv"]["n"].sum()
 GEOJSON_OBJECTS = load_geojson_objects()

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -400,6 +400,7 @@ def create_selected_question_bar_plot():
     )
 
     return dmc.Stack(
+        id="selected-question-container",
         children=[
             title,
             figure,

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -10,6 +10,7 @@ from .make_descriptive_plots import make_descriptive_plots
 from .make_map import make_map
 from .make_stacked_bar_plots import make_stacked_bar
 from .utility import (  # IMPACT_COLORMAP,; OPINION_COLORMAP,
+    ALL_STATES_LABEL,
     DEFAULT_QUESTION,
     SECTION_TITLES,
 )
@@ -263,7 +264,7 @@ def create_header():
     )
 
 
-def create_question_title():
+def create_map_title():
     """Create the title for the map section of the dashboard."""
     return dmc.Stack(
         children=[
@@ -379,7 +380,7 @@ def create_selected_question_bar_plot():
     """Create the component holding a title and stacked bar plot for the selected question."""
     title = dmc.Title(
         id="selected-question-title",
-        children="Response distribution, National",
+        children=f"{SECTION_TITLES['selected_question']}, {ALL_STATES_LABEL}",
         order=4,
         fw=300,
     )
@@ -407,6 +408,18 @@ def create_selected_question_bar_plot():
         ],
         gap=0,
         align="center",
+        pb="sm",
+    )
+
+
+def create_all_questions_section_title() -> dmc.Title:
+    """Create a title for the section containing the bar plots for all questions."""
+    return dmc.Title(
+        id="all-questions-title",
+        children=f"{SECTION_TITLES['all_questions']}, {ALL_STATES_LABEL}",
+        order=3,
+        fw=300,
+        pb="sm",
     )
 
 
@@ -491,10 +504,11 @@ def create_main():
                 mx="xs",
                 fluid=True,
                 children=[
-                    create_question_title(),
+                    create_map_title(),
                     create_impact_dropdown(),
                     create_map_plot(),
                     create_selected_question_bar_plot(),
+                    create_all_questions_section_title(),
                     create_domain_tabs(),
                 ],
             )

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -319,7 +319,6 @@ def create_impact_dropdown():
 
 def create_map_plot():
     """Create the component holding the cloropleth map plot of US states."""
-    # TODO: Ensure that state click events are handled properly
     us_map = dmc.Container(
         # TODO: Make map margins smaller (or create a param for this, maybe), and make figure height larger (?)
         dcc.Graph(

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -521,5 +521,5 @@ def construct_layout():
     return dmc.AppShell(
         children=[create_header(), create_navbar(), create_main()],
         header={"height": HEADER_HEIGHT},
-        navbar={"width": 400},
+        navbar={"width": 300},
     )

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -352,7 +352,6 @@ def create_stacked_bars_for_question(question_id: str, subquestion_id: str):
             id={
                 "type": "stacked-bar-plot",
                 "question": question_id,
-                "subquestion": subquestion_id,
             },
             figure=make_stacked_bar(
                 question=question_id,
@@ -360,7 +359,6 @@ def create_stacked_bars_for_question(question_id: str, subquestion_id: str):
                 state=None,
                 stratify=False,
                 threshold=DEFAULT_QUESTION["outcome"],
-                binarize_threshold=True,
             ),
         ),
         w=1200,

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -451,8 +451,23 @@ def create_domain_tabs():
             dmc.TabsPanel(
                 id=domain_full,
                 children=[
-                    create_domain_heading(domain_full),
-                    create_bar_plots_for_domain(domain_text=domain_full),
+                    dcc.Loading(
+                        id={
+                            "type": "domain-loading-overlay",
+                            "domain": domain_full,
+                        },
+                        children=[
+                            create_domain_heading(domain_full),
+                            create_bar_plots_for_domain(
+                                domain_text=domain_full
+                            ),
+                        ],
+                        overlay_style={
+                            "visibility": "visible",
+                            "filter": "blur(2px)",
+                        },
+                        type="circle",
+                    ),
                 ],
                 value=domain_full,
                 pt="sm",

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -15,6 +15,13 @@ from .utility import (  # IMPACT_COLORMAP,; OPINION_COLORMAP,
 )
 
 HEADER_HEIGHT = 110
+SINGLE_SUBQUESTION_FIG_KW = {
+    "fontsize": 10,
+    # NOTE: Can calculate same actual height as create_bar_plots_for_question with:
+    # ( default height - (default-set margin top) - (default-set margin bottom) )
+    "height": 105,
+    "margin": {"l": 30, "r": 30, "t": 5, "b": 20},
+}
 
 
 def create_question_dropdown():
@@ -342,7 +349,8 @@ def create_question_heading(question_label: str) -> dmc.Text:
     )
 
 
-def create_stacked_bars_for_question(question_id: str, subquestion_id: str):
+# TODO: Refactor args
+def create_bar_plots_for_question(question_id: str, subquestion_id: str):
     """
     Create component to hold the stacked bar plot(s) for a single subquestion
     or all subquestions for a question.
@@ -367,15 +375,49 @@ def create_stacked_bars_for_question(question_id: str, subquestion_id: str):
     return figure
 
 
+def create_selected_question_bar_plot():
+    """Create the component holding a title and stacked bar plot for the selected question."""
+    title = dmc.Title(
+        id="selected-question-title",
+        children="Response distribution, National",
+        order=4,
+        fw=300,
+    )
+
+    figure = dmc.Container(
+        dcc.Graph(
+            id="selected-question-bar-plot",
+            figure=make_stacked_bar(
+                question=DEFAULT_QUESTION["question"],
+                subquestion=DEFAULT_QUESTION["sub_question"],
+                state=None,
+                stratify=False,
+                threshold=DEFAULT_QUESTION["outcome"],
+                fig_kw=SINGLE_SUBQUESTION_FIG_KW,
+            ),
+        ),
+        w=1200,
+    )
+
+    return dmc.Stack(
+        children=[
+            title,
+            figure,
+        ],
+        gap=0,
+        align="center",
+    )
+
+
 def create_question_components(q_row: pd.Series) -> list:
     """Create a heading and stacked bar plot component for each question."""
     return [
         create_question_heading(q_row["full_text"]),
-        create_stacked_bars_for_question(q_row["question"], "all"),
+        create_bar_plots_for_question(q_row["question"], "all"),
     ]
 
 
-def create_stacked_bar_plots_for_domain(domain_text: str):
+def create_bar_plots_for_domain(domain_text: str):
     """Create component to hold the stacked bar plot(s) for all questions in a domain."""
     questions_df = DATA_DICTIONARIES["question_dictionary.tsv"]
     domain_df = questions_df.loc[
@@ -410,9 +452,7 @@ def create_domain_tabs():
                 id=domain_full,
                 children=[
                     create_domain_heading(domain_full),
-                    create_stacked_bar_plots_for_domain(
-                        domain_text=domain_full
-                    ),
+                    create_bar_plots_for_domain(domain_text=domain_full),
                 ],
                 value=domain_full,
                 pt="sm",
@@ -438,6 +478,7 @@ def create_main():
                     create_question_title(),
                     create_impact_dropdown(),
                     create_map_plot(),
+                    create_selected_question_bar_plot(),
                     create_domain_tabs(),
                 ],
             )

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -16,6 +16,11 @@ from .utility import (  # IMPACT_COLORMAP,; OPINION_COLORMAP,
 )
 
 HEADER_HEIGHT = 110
+
+SUPP_TEXT = {
+    "weighted_descriptives": "*N are unweighted while proportions are weighted according to census estimates for age, sex, race, and ethnicity",
+}
+
 SINGLE_SUBQUESTION_FIG_KW = {
     "fontsize": 10,
     # NOTE: Can calculate same actual height as create_bar_plots_for_question with:
@@ -93,6 +98,14 @@ def create_drawer_sample_size():
     return dmc.Text(id="drawer-sample-size", size="md")
 
 
+def create_sample_descriptive_note():
+    """Create the note for the sample characteristics section."""
+    return dmc.Text(
+        children=SUPP_TEXT["weighted_descriptives"],
+        size="xs",
+    )
+
+
 def create_sample_descriptive_plot():
     """Create the component holding the subplots of sample descriptive statistics."""
     return dcc.Graph(
@@ -120,6 +133,7 @@ def create_sample_description_drawer():
                     create_drawer_state(),
                     create_drawer_sample_size(),
                     create_sample_descriptive_plot(),
+                    create_sample_descriptive_note(),
                 ],
                 title=dmc.Title(
                     SECTION_TITLES["demographics"], order=3, fw=300

--- a/climate_emotions_map/make_stacked_bar_plots.py
+++ b/climate_emotions_map/make_stacked_bar_plots.py
@@ -345,9 +345,8 @@ def make_stacked_bar(
     fig_kw : dict, optional
         A dictionary of figure parameters. The default is None.
     """
-    if fig_kw is None:
-        # We need to make a deep copy to avoid modifying the default values!
-        fig_kw = copy.deepcopy(DEFAULT_FIG_KW)
+    # We need to make a deep copy to avoid modifying the global figure parameters
+    fig_kw = copy.deepcopy(DEFAULT_FIG_KW if fig_kw is None else fig_kw)
 
     if palettes is None:
         palettes = PALETTES_BY_LENGTH

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -38,6 +38,7 @@ def get_question_options():
     ].groupby("question")
 
     data = []
+    # TODO: Try to refactor this to not use iterrows
     for _, q_row in DATA_DICTIONARIES["question_dictionary.tsv"].iterrows():
         question = q_row["question"]
         question_label = q_row["full_text"]

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -2,7 +2,12 @@
 
 from .data_loader import DATA_DICTIONARIES, SURVEY_DATA
 
-DEFAULT_QUESTION = {"question": "q2", "sub_question": "1", "outcome": "3+"}
+DEFAULT_QUESTION = {
+    "domain": "Climate emotions & beliefs",
+    "question": "q2",
+    "sub_question": "1",
+    "outcome": "3+",
+}
 # TODO: Revisit title
 SECTION_TITLES = {
     "app": "US Climate Emotions Map",

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -8,12 +8,13 @@ DEFAULT_QUESTION = {
     "sub_question": "1",
     "outcome": "3+",
 }
-# TODO: Revisit title
+ALL_STATES_LABEL = "National"
 SECTION_TITLES = {
     "app": "US Climate Emotions Map",
-    "map_opinions": "Map: Percent (%) of adolescents and young adults who endorse the following question/statement:",
+    "map_opinions": "Percent (%) of adolescents and young adults who endorse the following question/statement:",
     "map_impacts": "Map: Percent (%) of adolescents and young adults who reported experiencing the following in the last year",
-    "bar_charts": "Climate emotions and thoughts of adolescents and young adults",
+    "selected_question": "Response distribution",
+    "all_questions": "Climate emotions and thoughts of adolescents and young adults",
     "demographics": "Sample Characteristics",
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ cryptography==42.0.5
     # via
     #   pyopenssl
     #   urllib3
-dash==2.17.0
+dash==2.16.1
     # via -r requirements.in
 dash-core-components==2.0.0
     # via dash

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ cryptography==42.0.5
     # via
     #   pyopenssl
     #   urllib3
-dash==2.16.1
+dash==2.17.0
     # via -r requirements.in
 dash-core-components==2.0.0
     # via dash


### PR DESCRIPTION
- Closes #21  
- Closes #34
- Closes #37
- Closes #54
- Closes #46 

### Other changes proposed in this PR
- Add loading spinner for domain tabs when bar chart options are updated, since updating all question bar plots is currently quite slow
- Add bar plot for the currently selected question under the map (this will be hidden if a weather impact is selected)
- Add note about weighted sample characteristics in drawer (from manuscript)