### PR TITLE
Update plot formatting

### DIFF
--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -123,8 +123,10 @@ def update_drawer_sample_size(value):
     """Callback function for updating the sample size in the drawer."""
     df = SURVEY_DATA["samplesizes_state.tsv"]
     if value is None:
-        return f"Sample size: {NATIONAL_SAMPLE_SIZE}"
-    return f"Sample size: {df[df['state'] == value]['n'].values[0]}"
+        sample_size = NATIONAL_SAMPLE_SIZE
+    else:
+        sample_size = df[df["state"] == value]["n"].values[0]
+    return f"Sample size: {sample_size:,}"
 
 
 @callback(

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -121,6 +121,7 @@ def create_sample_descriptive_plot():
         figure=make_descriptive_plots(
             state=None,
         ),
+        config={"displayModeBar": False},
         # TODO: Revisit
         # We use px instead of viewport height here for now to more easily control scrolling
         # on smaller screens
@@ -341,7 +342,7 @@ def create_map_plot():
             ),
             # vh = % of viewport height
             # TODO: Revisit once plot margins are adjusted
-            config={"scrollZoom": False},
+            config={"displayModeBar": False, "scrollZoom": False},
             style={"height": "65vh"},
         ),
         # set max width
@@ -394,6 +395,7 @@ def create_bar_plots_for_question(question_id: str, subquestion_id: str):
                 stratify=False,
                 threshold=DEFAULT_QUESTION["outcome"],
             ),
+            config={"displayModeBar": False},
         ),
         w=1200,
         # size="xl",
@@ -421,6 +423,7 @@ def create_selected_question_bar_plot():
                 threshold=DEFAULT_QUESTION["outcome"],
                 fig_kw=SINGLE_SUBQUESTION_FIG_KW,
             ),
+            config={"displayModeBar": False},
         ),
         w=1200,
     )

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -138,6 +138,8 @@ SUBPLOT_POSITIONS = {
     Q2_LABEL: (11, 1),
 }
 
+DECIMALS = 0
+
 
 def get_categories_dict(df: pd.DataFrame) -> dict:
     """
@@ -231,7 +233,7 @@ def make_descriptive_plot_traces(
             #     for n, percentage in zip(df[COL_N], df[COL_PERCENTAGE])
             # ],
             hovertemplate=(
-                "<b>%{customdata[1]}</b>: %{x:.1f}% (%{customdata[0]})"
+                f"<b>%{{customdata[1]}}</b>: %{{x:.{DECIMALS}f}}% (%{{customdata[0]}})"
                 "<extra></extra>"
             ),
             marker_color=marker_color,
@@ -288,7 +290,7 @@ def make_impact_plot_traces(
                 customdata=list(zip(x, data_category[COL_N])),
                 hovertemplate=(
                     "<b>%{customdata[0]}</b>"
-                    ": %{y:.2f}% (%{customdata[1]})"
+                    f": %{{y:.{DECIMALS}f}}% (%{{customdata[1]}})"
                     "<extra></extra>"
                 ),
                 marker_color=marker_color,

--- a/climate_emotions_map/make_map.py
+++ b/climate_emotions_map/make_map.py
@@ -64,6 +64,7 @@ def make_map(
     impact_marker_size_scale: float = 1.0,
     colormap_range_padding: int = 10,
     margins: dict = None,
+    decimals: int = 0,
 ) -> go.Figure:
     """Generate choropleth map showing opinion and/or impact data.
 
@@ -95,6 +96,8 @@ def make_map(
         Padding for the colormap vmin/vmax range, by default 10
     margins : dict | None, optional
         Margins for the Plotly figure, by default 30 everywhere
+    decimals : int, optional
+        Number of decimals to show in the hoverbox, by default 0
 
     Returns
     -------
@@ -231,9 +234,7 @@ def make_map(
     # if gradient and scatter dots
     if impact is not None and not show_impact_as_gradient:
         customdata_cols.append(col_color_impact)
-        hovertemplate_extra = (
-            f"<br>{col_color_impact.capitalize()}: %{{customdata[2]:.1f}}%"
-        )
+        hovertemplate_extra = f"<br>{col_color_impact.capitalize()}: %{{customdata[2]:.{decimals}f}}%"
     fig.add_choropleth(
         locations=df_hover_data["state_abbreviated"],
         locationmode="USA-states",
@@ -244,7 +245,7 @@ def make_map(
         hovertemplate=(
             "<b>%{customdata[0]}</b>"
             "<br>Sample size: %{customdata[1]}"
-            f"<br>{col_gradient.replace('<br>', ' ').capitalize()}: %{{z:.1f}}%"
+            f"<br>{col_gradient.replace('<br>', ' ').capitalize()}: %{{z:.{decimals}f}}%"
             f"{hovertemplate_extra}"
             "<extra></extra>"
         ),

--- a/climate_emotions_map/make_stacked_bar_plots.py
+++ b/climate_emotions_map/make_stacked_bar_plots.py
@@ -135,7 +135,7 @@ def plot_bars(
     y="question",
     color="outcome",
     title=None,  # TODO: remove this argument?
-    round_to=3,
+    round_to=2,  # NOTE: This is the number of decimal places to round the data to, BEFORE multiplying by 100.
     sort_order="descending",
     facet_order=None,
     palette=None,
@@ -144,6 +144,10 @@ def plot_bars(
 ) -> px.bar:
     """Make a stacked bar plot of the opinions of the whole sample, split by state and party."""
     facet_var = "sub_question"
+
+    # Determine the appropriate number of decimal places to use after converting data
+    # to percentages based on the applied rounding, to use in hover text
+    decimals = max(0, round_to - 2)
 
     plot_df[x] = plot_df[x].round(round_to) * 100
 
@@ -183,12 +187,13 @@ def plot_bars(
 
     full_text_series = outcome_dict_df.set_index("key")["full_text"]
     plot_df["full_text"] = plot_df["key"].map(full_text_series)
+    # Format the text to display on the bars
     plot_df["annotate_text"] = (
         wrap_column_text(
             df=plot_df, column="full_text", width=FACET_LAYOUTS["text_wrap"]
         )
         + "<br>"
-        + plot_df[x].round(3).astype(str)
+        + plot_df[x].apply(lambda y: f"{y:.{decimals}f}")
         + "%"
     )
 
@@ -205,11 +210,12 @@ def plot_bars(
 
     # Define custom hover data
     custom_data = ["full_text"]
+    # Format the hover text
     # <extra></extra> hides the secondary box that appears when hovering over the bars
     hovertemplate = "<br>".join(
         [
             "Outcome: %{customdata[0]}",
-            "Percentage: %{x:.1f}%",
+            f"Percentage: %{{x:.{decimals}f}}%",
             "<extra></extra>",
         ]
     )


### PR DESCRIPTION
- Closes #65

This PR addresses changes requested by Eric:
- Update rounding in plotting functions to nearest whole number to match manuscript
- Hide Plotly toolbars in figures
- Format sample size number in sample characteristics drawer to have comma separators (e.g., 1,234 instead of 1234)