### PR TITLE
[ENH] Update titles, default question, and remove custom handling of `noanswer` subquestions

### DIFF
--- a/climate_emotions_map/app.py
+++ b/climate_emotions_map/app.py
@@ -257,8 +257,8 @@ def update_selected_question_bar_plot(
 def update_selected_question_title(state):
     """Update the title for the selected question based on the selected state."""
     if state is None:
-        return f"{SECTION_TITLES['selected_question']}, {ALL_STATES_LABEL}"
-    return f"{SECTION_TITLES['selected_question']}, {state}"
+        return ALL_STATES_LABEL
+    return state
 
 
 @callback(
@@ -281,8 +281,8 @@ def toggle_selected_question_bar_plot_visibility(impact):
 def update_all_questions_title(state):
     """Update the title for the section for all questions based on the selected state."""
     if state is None:
-        return f"{SECTION_TITLES['all_questions']}, {ALL_STATES_LABEL}"
-    return f"{SECTION_TITLES['all_questions']}, {state}"
+        return f"{SECTION_TITLES['all_questions']}: {ALL_STATES_LABEL}"
+    return f"{SECTION_TITLES['all_questions']}: {state}"
 
 
 @callback(

--- a/climate_emotions_map/data_loader.py
+++ b/climate_emotions_map/data_loader.py
@@ -14,7 +14,9 @@ import pandas as pd
 def load_data_file(file: str) -> pd.DataFrame:
     """Load a TSV data file into a dataframe."""
     return pd.read_csv(
-        Path(__file__).parents[1] / "data" / "survey_results" / file, sep="\t"
+        Path(__file__).parents[1] / "data" / "survey_results" / file,
+        sep="\t",
+        dtype={"question": str, "sub_question": str, "outcome": str},
     )
 
 
@@ -26,6 +28,7 @@ def load_data_dictionary(file: str) -> pd.DataFrame:
         # Some data dictionaries have "None" as a meaningful value, so we have to prevent it
         # from being interpreted as a NaN by pandas
         keep_default_na=False,
+        dtype={"question": str, "sub_question": str, "outcome": str},
     )
 
 
@@ -103,10 +106,7 @@ def get_subquestion_order():
     for the 3+ outcome, for the whole sample.
     """
     df = SURVEY_DATA["opinions_wholesample.tsv"]
-    # TODO: Fix this hack!
-    df_thres = df.loc[
-        (df["outcome"] == "3+") & (df["sub_question"] != "noanswer")
-    ]
+    df_thres = df.loc[df["outcome"] == "3+"]
 
     subquestion_order = {}
     for question, group in df_thres.groupby("question"):

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -237,7 +237,7 @@ def create_app_subtitle():
     """Create the subtitle for the dashboard."""
     return dmc.Text(
         children=[
-            'Graphical appendix for "Climate emotions, thoughts, and plans among US adolescents and young adults:',
+            'Graphical appendix for "Climate emotions, thoughts, and plans among US adolescents and young adults: ',
             "a cross-sectional descriptive survey and analysis by political party identification and self-reported exposure to severe weather events. ",
             "(Lewandowski, R.E, Clayton, S.D., Olbrich, L., Sakshaug, J.W., Wray, B. et al, (2024) ",
             html.I("Lancet Planetary Health, "),

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -18,7 +18,7 @@ from .utility import (  # IMPACT_COLORMAP,; OPINION_COLORMAP,
 HEADER_HEIGHT = 110
 
 SUPP_TEXT = {
-    "weighted_descriptives": "*N are unweighted while proportions are weighted according to census estimates for age, sex, race, and ethnicity",
+    "weighted_descriptives": "*N are unweighted while proportions are weighted according to US census estimates for age, sex, race, and ethnicity",
 }
 
 MAP_LAYOUT = {
@@ -316,7 +316,7 @@ def create_impact_dropdown():
     return dmc.Flex(
         dmc.Select(
             id="impact-select",
-            label="View distribution of self-reported severe weather event",
+            label="Distribution of severe weather events (self-reported)",
             placeholder="Select a severe weather event",
             data=utils.get_impact_options(),
             clearable=True,
@@ -407,7 +407,7 @@ def create_selected_question_bar_plot():
     """Create the component holding a title and stacked bar plot for the selected question."""
     title = dmc.Title(
         id="selected-question-title",
-        children=f"{SECTION_TITLES['selected_question']}, {ALL_STATES_LABEL}",
+        children=ALL_STATES_LABEL,
         order=4,
         fw=300,
     )
@@ -444,7 +444,7 @@ def create_all_questions_section_title() -> dmc.Title:
     """Create a title for the section containing the bar plots for all questions."""
     return dmc.Title(
         id="all-questions-title",
-        children=f"{SECTION_TITLES['all_questions']}, {ALL_STATES_LABEL}",
+        children=f"{SECTION_TITLES['all_questions']}: {ALL_STATES_LABEL}",
         order=3,
         fw=300,
         pb="sm",

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -170,7 +170,8 @@ def create_sample_description_drawer():
 def create_design_credit():
     """Create the text hovercard for web app developer details."""
     short_credit = dmc.Text(
-        children="Built by members of the ORIGAMI Lab",
+        children="Web application built by members of the ORIGAMI Lab",
+        ta="center",
         size="xs",
         c="dimmed",
     )
@@ -236,12 +237,13 @@ def create_app_subtitle():
     """Create the subtitle for the dashboard."""
     return dmc.Text(
         children=[
-            'Graphical appendix for "Climate emotions, thoughts, and plans among US adolescents and young adults" \n(Lewandowski, R.E, Clayton, S.D., Olbrich, L., Sakshaug, J.W., Wray, B. et al, (2024) ',
+            'Graphical appendix for "Climate emotions, thoughts, and plans among US adolescents and young adults:',
+            "a cross-sectional descriptive survey and analysis by political party identification and self-reported exposure to severe weather events. ",
+            "(Lewandowski, R.E, Clayton, S.D., Olbrich, L., Sakshaug, J.W., Wray, B. et al, (2024) ",
             html.I("Lancet Planetary Health, "),
-            "(volume, issue, tbd)",
+            "(volume, issue, tbd))",
         ],
         size="sm",
-        c="dimmed",
         style={"whiteSpace": "pre-wrap"},
     )
 
@@ -273,14 +275,7 @@ def create_header():
                                     create_app_subtitle(),
                                 ],
                             ),
-                            span="content",
-                        ),
-                        dmc.GridCol(
-                            dmc.Group(
-                                justify="flex-end",
-                                # TODO: Add GitHub link? Not sure if needed/wanted.
-                            ),
-                            span="auto",
+                            span="12",
                         ),
                     ],
                 ),

--- a/climate_emotions_map/layout.py
+++ b/climate_emotions_map/layout.py
@@ -37,6 +37,7 @@ def create_question_dropdown():
     """
     Create the dropdown for subquestions grouped by question.
     NOTE: 'value' must be a string for DMC, so we use f-strings to concatenate the question and subquestion.
+    NOTE: Some questions include a '_' character in the id, so when extracting the question and subquestion we always need to split on the last '_'.
     """
     return dmc.Select(
         id="question-select",

--- a/climate_emotions_map/make_descriptive_plots.py
+++ b/climate_emotions_map/make_descriptive_plots.py
@@ -37,8 +37,8 @@ Q2_LABEL = "q2"
 # order in the lists determines order in the plots
 CATEGORY_ORDERS = {
     "age": [
-        "under 18",
-        "18+",
+        "16-17",
+        "18-25",
     ],
     "sex": [
         "Female",

--- a/climate_emotions_map/make_stacked_bar_plots.py
+++ b/climate_emotions_map/make_stacked_bar_plots.py
@@ -367,10 +367,7 @@ def make_stacked_bar(
     # assert (
     #     question in df["question"].unique()
     # ), f"Question {question} not found in data."
-    # TODO: Remove temporary workaround for "noanswer" subquestion
-    q_df = df.loc[
-        (df["question"] == question) & (df["sub_question"] != "noanswer")
-    ].copy()
+    q_df = df.loc[df["question"] == question].copy()
 
     # check subquestion
     if subquestion == "all":

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -4,17 +4,16 @@ from .data_loader import DATA_DICTIONARIES, SURVEY_DATA
 
 DEFAULT_QUESTION = {
     "domain": "Climate emotions & beliefs",
-    "question": "q2",
+    "question": "q4",
     "sub_question": "1",
     "outcome": "3+",
 }
 ALL_STATES_LABEL = "National"
 SECTION_TITLES = {
-    "app": "US Climate Emotions Map",
+    "app": "US Climate Emotions Map (16-25 years old)",
     "map_opinions": "Percent (%) of adolescents and young adults who endorse the following question/statement:",
     "map_impacts": "Map: Percent (%) of adolescents and young adults who reported experiencing the following in the last year",
-    "selected_question": "Response distribution",
-    "all_questions": "Climate emotions and thoughts of adolescents and young adults",
+    "all_questions": "Select a survey domain to view responses for",
     "demographics": "Sample Characteristics",
 }
 

--- a/climate_emotions_map/utility.py
+++ b/climate_emotions_map/utility.py
@@ -68,7 +68,8 @@ def get_question_options():
 
 def extract_question_subquestion(value: str) -> tuple[str, str]:
     """Extract the question and subquestion from a value in the question dropdown."""
-    question, sub_question = value.split("_")
+    # NOTE: We split on the last occurrence of "_" to account for underscores in the question ID
+    question, sub_question = value.rsplit("_", 1)
     return question, sub_question
 
 


### PR DESCRIPTION
Closes #73 

Other changes proposed in this PR:

- Extraction of a selected question's question ID & subquestion ID in callbacks updated to account for possible `_` in question IDs now (e.g., q13_noanswer) 
- Data loader also updated following restructuring of q13 / q14 noanswer subquestions to ensure that question & subquestion columns are read in as strings