### PR TITLE
[CI] Fix wf to push built Docker image to AWS Lightsail

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -28,14 +28,17 @@ jobs:
         -   name: Set up Docker Buildx
             uses: docker/setup-buildx-action@v3
 
+        # NOTE: 'load' is needed for the image to be available for the next steps
         -   name: Build and push to DockerHub
             uses: docker/build-push-action@v6
             with:
                 context: .
                 file: ./Dockerfile
+                load: true
                 push: true
                 tags: ${{ env.DOCKER_IMAGE }}
 
+        # Sanity check
         -   name: List Docker images
             run: docker images
 


### PR DESCRIPTION
(Troubleshooting failure to find built image in: https://github.com/neurodatascience/us_climate_emotions_map/actions/runs/10837260230)

- Load image during build step to make it available in other steps (see `load` in https://github.com/docker/build-push-action?tab=readme-ov-file#inputs)