### PR TITLE
[CI] Detect submodule changes using `git status` instead of `git pull`

### DIFF
--- a/.github/workflows/update_submodule.yml
+++ b/.github/workflows/update_submodule.yml
@@ -28,15 +28,13 @@ jobs:
 
         -   name: Update submodule
             run: |
-                cd data
-                git switch main
-                output=$(git pull)
+                git submodule update --remote -- data
+                output=$(git status -s data)
                 echo "$output"
-                cd ..
-                if [[ "$output" != *"Already up to date."* ]]; then
+                # Check if the status output is non-empty
+                if [[ -n "$output" ]]; then
                     ./code/create_prerendered_figures.py
                 fi
-
 
         -   name: Create pull request
             uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
Using the output of `git pull` run on the submodule `main` branch to signal if there are any new changes in the submodule doesn't really work because even as the submodule has updated to point to the latest commit, `git pull`  will still show as `Already up to date`. It's only when we check the status of the parent repo (`..`) that we'll see changes in the `data` directory.

Current behaviour: even though the wf correctly detects uncommitted changes in the working directory _after_ the `Update submodule` step (because it is looking for changes in the directory root) + then correctly opens a PR to update the submodule pointer, _during_ the step, the script to regenerate figures is not triggered.

To resolve this, we use the output of `git status` in the root as the indicator of submodule changes instead.